### PR TITLE
Change dialog disposal order in `DnDActionChooser` action listeners

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/plugins/DnDHandlerPlugin.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/DnDHandlerPlugin.java
@@ -85,7 +85,7 @@ public class DnDHandlerPlugin extends AbstractIOPlugin< Object >
 		final Path droppedInPath = fileLocation.getFile().toPath();
 
 		//TODO: this should ideally go into a separate thread... as an independent follow-up story after the DnD event is over
-		new DnDActionChooser( droppedInPath, this.context() ).show();
+		new DnDActionChooser( droppedInPath, this.context() ).showDialog();
 
 		// Returning such an object makes Scijava's DnD subsystem believe that the dropped object
 		// has been already fully loaded, and Scijava (Fiji) will attempt to display it now (and

--- a/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
+++ b/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
@@ -13,6 +13,7 @@ import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import java.awt.AWTError;
 import java.awt.Dimension;
@@ -76,7 +77,19 @@ public class DnDActionChooser
 		logger.debug( "Show extended version: {}", show );
 	}
 
-	public void show()
+	public void showDialog()
+	{
+		if ( SwingUtilities.isEventDispatchThread() )
+		{
+			doShow();
+		}
+		else
+		{
+			SwingUtilities.invokeLater( this::doShow );
+		}
+	}
+
+	private void doShow()
 	{
 		final Point mouseLocation = getMouseLocation();
 		if ( mouseLocation == null )

--- a/src/test/java/sc/fiji/ome/zarr/ui/DnDActionChooserDemo.java
+++ b/src/test/java/sc/fiji/ome/zarr/ui/DnDActionChooserDemo.java
@@ -30,7 +30,7 @@ public class DnDActionChooserDemo
 			@Override
 			public void actionPerformed( ActionEvent e )
 			{
-				menu.show();
+				menu.showDialog();
 			}
 		} );
 


### PR DESCRIPTION
* First close the Drag'n'Drop dialog (and thereby close the event handling)
* Only then, open a new dialog window.