### PR TITLE
Add utility function BdvShowAndRegister

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/plugins/OpenInBDVCommand.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/OpenInBDVCommand.java
@@ -37,9 +37,8 @@ import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
-import bdv.util.BdvFunctions;
-import bdv.util.BdvOptions;
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
+import sc.fiji.ome.zarr.util.BdvUtils;
 
 @Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Open Current Zarr Image in BigDataViewer" )
 public class OpenInBDVCommand implements Command
@@ -60,8 +59,7 @@ public class OpenInBDVCommand implements Command
 		{
 			logService.log( 0, "Opening " + dataset.getClass() + " in BDV..." );
 			PyramidalDataset< ? > pyramidalDataset = Cast.unchecked( dataset );
-			BdvFunctions.show( pyramidalDataset.asSources(), pyramidalDataset.numTimepoints(),
-					BdvOptions.options().frameTitle( pyramidalDataset.getName() ) );
+			BdvUtils.showBdvAndRegisterDataset( pyramidalDataset );
 		}
 		else
 		{

--- a/src/main/java/sc/fiji/ome/zarr/util/BdvUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/BdvUtils.java
@@ -17,6 +17,15 @@ public class BdvUtils
 		// prevent instantiation of this class
 	}
 
+	/**
+	 * Displays the given pyramidal dataset in a BigDataViewer (BDV) window.<br>
+	 * Increments the dataset's reference count.<br>
+	 * Ensures that the dataset's reference count is properly decreased when the BDV window is closed.
+	 * <br>
+	 * @param pyramidalDataset the input dataset to be displayed in BDV; this dataset
+	 *                         contains multi-resolution image data along with associated metadata.
+	 * @return a {@code BdvHandle} instance representing the BDV window.
+	 */
 	public static BdvHandle showBdvAndRegisterDataset( final PyramidalDataset< ? > pyramidalDataset )
 	{
 		BdvHandle bdvHandle = BdvFunctions.show( pyramidalDataset.asSources(), pyramidalDataset.numTimepoints(),
@@ -33,9 +42,7 @@ public class BdvUtils
 				@Override
 				public void windowClosed( WindowEvent e )
 				{
-					System.out.println( "Closing BDV Window..." );
 					pyramidalDataset.decrementReferences();
-					System.out.println( "Decremented references of pyramidal dataset" );
 				}
 			} );
 		}

--- a/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
@@ -10,22 +10,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.Desktop;
-import java.awt.Container;
-import java.awt.Window;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.util.Cast;
 
 import bdv.util.BdvFunctions;
-import bdv.util.BdvOptions;
 import bdv.util.BdvHandle;
 import ij.IJ;
 import sc.fiji.ome.zarr.pyramid.DefaultPyramidal5DImageData;
@@ -86,37 +82,23 @@ public class ZarrOpenActions
 	public void openIJWithImage()
 	{
 		openImage(
-				pyramidalDataset -> context.getService( UIService.class ).show( pyramidalDataset ),
+				pyramidalDataset -> {
+					context.getService( UIService.class ).show( pyramidalDataset );
+					return null;
+				},
 				singleScaleImage -> ImageJFunctions.show( Cast.unchecked( singleScaleImage ) ),
 				"ImageJ"
 		);
 	}
 
-	public void openBDVWithImage()
+	public BdvHandle openBDVWithImage()
 	{
-		openImage(
-				pyramidalDataset -> {
-					BdvHandle bdvHandle = BdvFunctions.show( pyramidalDataset.asSources(), pyramidalDataset.numTimepoints(),
-							BdvOptions.options().frameTitle( pyramidalDataset.getName() ) ).getBdvHandle();
-
-					Container topLevelContainer = bdvHandle.getViewerPanel().getRootPane().getParent();
-					if ( topLevelContainer instanceof Window )
-					{
-						// notify scijava about "usage" (and "no longer usage" later) of this Dataset
-						// only iff we're able to listen for when Bdv window closes
-						pyramidalDataset.incrementReferences();
-						( ( Window ) topLevelContainer ).addWindowListener( new WindowAdapter()
-						{
-							@Override
-							public void windowClosed( WindowEvent e )
-							{
-								pyramidalDataset.decrementReferences();
-							}
-						} );
-					}
-				},
+		Object result = openImage(
+				BdvUtils::showBdvAndRegisterDataset,
 				singleScaleImage -> BdvFunctions.show( singleScaleImage, "Image" ),
-				"BigDataViewer" );
+				"BigDataViewer"
+		);
+		return Cast.unchecked( result );
 	}
 
 	private void showSingleScaleError( final Exception e )
@@ -133,13 +115,15 @@ public class ZarrOpenActions
 		logger.warn( "Could not open dataset as non-Zarr image: {}. Error message: {}", droppedInPath, e.getMessage() );
 	}
 
-	void openImage( final Consumer< PyramidalDataset< ? > > multiScaleImageOpener, final Consumer< Img< ? > > singleScaleImageOpener,
+	Object openImage( final Function< PyramidalDataset< ? >, Object > multiScaleImageOpener,
+			final Consumer< Img< ? > > singleScaleImageOpener,
 			final String message )
 	{
 		try
 		{
-			openMultiScaleImage( multiScaleImageOpener );
+			Object result = openMultiScaleImage( multiScaleImageOpener );
 			logger.info( "Opened dataset in {}: {}", message, droppedInPath );
+			return result;
 		}
 		catch ( NotAMultiscaleImageException e )
 		{
@@ -158,17 +142,18 @@ public class ZarrOpenActions
 		{
 			showNonZarrError( ex );
 		}
+		return null;
 	}
 
-	private void openMultiScaleImage( final Consumer< PyramidalDataset< ? > > multiScaleImageOpener ) throws NotAMultiscaleImageException
+	private Object openMultiScaleImage( final Function< PyramidalDataset< ? >, Object > multiScaleImageOpener )
+			throws NotAMultiscaleImageException
 	{
-
-		// final MultiscaleImage< ?, ? > multiscaleImage = new MultiscaleImage<>( droppedInPath.toString() );
 		final DefaultPyramidal5DImageData< ?, ? > pyramidal5DImageData =
 				new DefaultPyramidal5DImageData<>( context, droppedInPath.toString() );
 		PyramidalDataset< ? > pyramidalDataset = pyramidal5DImageData.asPyramidalDataset();
-		multiScaleImageOpener.accept( pyramidalDataset );
+		Object result = multiScaleImageOpener.apply( pyramidalDataset );
 		logger.info( "Opened multiscale image: {}", droppedInPath );
+		return result;
 	}
 
 	private void openSingleScaleImage( final Consumer< Img< ? > > singleScaleImageOpener ) throws NotASingleScaleImageException

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -3,13 +3,8 @@ package sc.fiji.ome.zarr.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static sc.fiji.ome.zarr.util.ZarrTestUtils.IMAGE_NAME;
-
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 import net.imagej.Dataset;
 import net.imagej.DatasetService;
@@ -17,6 +12,19 @@ import net.imglib2.img.Img;
 
 import org.junit.jupiter.api.Test;
 import org.scijava.Context;
+import org.scijava.display.DisplayService;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import bdv.util.BdvHandle;
+
+import javax.swing.SwingUtilities;
 
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
 
@@ -32,7 +40,7 @@ class ZarrOpenActionsTest
 			ZarrOpenActions actions = new ZarrOpenActions( path, context );
 			AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
 			AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-			Consumer< PyramidalDataset< ? > > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
+			Function< PyramidalDataset< ? >, Object > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
 			Consumer< Img< ? > > imgConsumer = img -> singleScaleCounter.incrementAndGet();
 			actions.openImage( multiScaleOpeningCounter, imgConsumer, "" );
 			assertEquals( 1, multiScaleCounter.get() );
@@ -55,7 +63,7 @@ class ZarrOpenActionsTest
 				ZarrOpenActions actions = new ZarrOpenActions( path, context );
 				AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
 				AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-				Consumer< PyramidalDataset< ? > > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
+				Function< PyramidalDataset< ? >, Object > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
 				Consumer< Img< ? > > imgConsumer = img -> singleScaleCounter.incrementAndGet();
 				actions.openImage( multiScaleOpeningCounter, imgConsumer, "" );
 				assertEquals( 0, multiScaleCounter.get() );
@@ -79,7 +87,7 @@ class ZarrOpenActionsTest
 			{
 				Path path = ZarrTestUtils.resourcePath( invalidPath );
 				ZarrOpenActions actions = new ZarrOpenActions( path, context, System.out::println );
-				Consumer< PyramidalDataset< ? > > multiScaleNoOp = dataset -> {};
+				Function< PyramidalDataset< ? >, Object > multiScaleNoOp = pyramidalDataset -> null;
 				Consumer< Img< ? > > singleScaleNoOp = img -> {};
 				assertDoesNotThrow( () -> actions.openImage( multiScaleNoOp, singleScaleNoOp, "" ) );
 			}
@@ -87,7 +95,7 @@ class ZarrOpenActionsTest
 	}
 
 	@Test
-	void testOpenDatasetImageJ() throws URISyntaxException
+	void testOpenMultiScaleDatasetInImageJ() throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/2d_testing/ome_zarr_v4_example" );
 		try (Context context = new Context())
@@ -102,25 +110,66 @@ class ZarrOpenActionsTest
 			assertEquals( 1, datasets.size() ); // The dataset service knows the dataset now
 			Dataset dataset = datasets.get( 0 );
 			assertEquals( IMAGE_NAME, dataset.getName() );
+			DisplayService displayService = context.getService( DisplayService.class );
+			assertNotNull( displayService );
+			displayService.getActiveDisplay().close(); // Close the active display / image
+			assertTrue( displayService.getDisplays().isEmpty() );
+			assertEquals( 0, datasetService.getDatasets().size() ); // The dataset is dereferenced now
 		}
 	}
 
 	@Test
-	void testOpenDatasetBDV() throws URISyntaxException
+	void testOpenSingleScaleImageInImageJ() throws URISyntaxException
+	{
+		Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/2d_testing/ome_zarr_v4_example/scale0/image" );
+		try (Context context = new Context())
+		{
+			ZarrOpenActions actions = new ZarrOpenActions( path, context );
+			actions.openIJWithImage();
+
+			DatasetService datasetService = context.getService( DatasetService.class );
+			assertNotNull( datasetService );
+			List< Dataset > datasets = datasetService.getDatasets();
+			assertNotNull( datasets );
+			assertEquals( 0, datasets.size() ); // A single scale image is opened as image not as dataset
+		}
+	}
+
+	@Test
+	void testOpenMultiScaleDatasetBDV() throws URISyntaxException, InterruptedException, InvocationTargetException
 	{
 		Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/2d_testing/ome_zarr_v4_example" );
 		try (Context context = new Context())
 		{
 			ZarrOpenActions actions = new ZarrOpenActions( path, context );
-			actions.openBDVWithImage();
+			BdvHandle bdvHandle = actions.openBDVWithImage();
 
 			DatasetService datasetService = context.getService( DatasetService.class );
 			assertNotNull( datasetService );
 			List< Dataset > datasets = datasetService.getDatasets();
 			assertNotNull( datasets );
 			assertEquals( 1, datasets.size() ); // The dataset service knows the dataset now
-			// TODO: try to get a BdvHandle here, close it and test if dataset.size() is 0 after closing
-			// TODO: add test for single scale image closing
+			bdvHandle.close();
+			// wait until all Swing events are processed
+			SwingUtilities.invokeAndWait( () -> {} );
+			datasets = datasetService.getDatasets();
+			assertEquals( 0, datasets.size() ); // The dataset service has correctly removed the dataset from the cache
+		}
+	}
+
+	@Test
+	void testOpenSingleScaleImageInBDV() throws URISyntaxException
+	{
+		Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/2d_testing/ome_zarr_v4_example/scale0/image" );
+		try (Context context = new Context())
+		{
+			ZarrOpenActions actions = new ZarrOpenActions( path, context );
+			actions.openBDVWithImage();
+			DatasetService datasetService = context.getService( DatasetService.class );
+			assertNotNull( datasetService );
+			List< Dataset > datasets = datasetService.getDatasets();
+			assertNotNull( datasets );
+			assertEquals( 0, datasets.size() ); // A single scale image is opened as image not as dataset
 		}
 	}
 }


### PR DESCRIPTION
**Refactoring and code organization:**

* Introduced a new utility class, `BdvUtils`, encapsulating the logic for displaying pyramidal datasets in BDV and managing reference counting, ensuring datasets are properly registered and deregistered when BDV windows are opened and closed. (`src/main/java/sc/fiji/ome/zarr/util/BdvUtils.java`)
* Updated `OpenInBDVCommand` and `ZarrOpenActions` to use `BdvUtils.showBdvAndRegisterDataset`

**API changes:**

* Changed the `openImage` and `openMultiScaleImage` methods in `ZarrOpenActions` to accept a `Function` (returning a result) instead of a `Consumer`, allowing callers to receive handles (such as `BdvHandle`)

**Testing enhancements:**

* Extended tests to verify that datasets are correctly registered and deregistered with the `DatasetService` when opened and closed in BDV and ImageJ, for both multi-scale and single-scale images. This includes simulating the closing of BDV windows and checking that resources are released as expected. (`src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java`)