### PR TITLE
Cleaning: Unified spelling of things, plugins moved to one package

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/plugins/DnDHandlerPlugin.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/DnDHandlerPlugin.java
@@ -73,7 +73,7 @@ public class DnDHandlerPlugin extends AbstractIOPlugin< Object >
 	public boolean supportsOpen( final Location source )
 	{
 		logger.debug(
-				"Zarr DnD plugin: supportsOpen check, location type={}, path={}", source.getClass().getSimpleName(),
+				"OME-Zarr DnD plugin: supportsOpen check, location type={}, path={}", source.getClass().getSimpleName(),
 				source.getURI().getPath()
 		);
 
@@ -86,7 +86,7 @@ public class DnDHandlerPlugin extends AbstractIOPlugin< Object >
 	@Override
 	public Object open( final Location source ) throws IOException
 	{
-		logger.debug( "Zarr DnD plugin: opening {}", source.getURI().getPath() );
+		logger.debug( "OME-Zarr DnD plugin: opening {}", source.getURI().getPath() );
 
 		final FileLocation fileLocation = Cast.unchecked( source );
 		final Path droppedInPath = fileLocation.getFile().toPath();

--- a/src/main/java/sc/fiji/ome/zarr/plugins/DragAndDropBehaviorSettings.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/DragAndDropBehaviorSettings.java
@@ -1,4 +1,4 @@
-package sc.fiji.ome.zarr.ui;
+package sc.fiji.ome.zarr.plugins;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Arrays;
@@ -20,8 +20,8 @@ import sc.fiji.ome.zarr.settings.ZarrOpenBehavior;
 /**
  * A FIJI/ImageJ command to select what to do when an OME-Zarr image is Drag &amp; Dropped into Fiji.
  */
-@Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Drag & Drop Behavior", initializer = "init" )
-public class ZarrDragAndDropOpenSettingsUI extends DynamicCommand
+@Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Drag & Drop Behavior Settings", initializer = "init" )
+public class DragAndDropBehaviorSettings extends DynamicCommand
 {
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
 

--- a/src/main/java/sc/fiji/ome/zarr/plugins/DragAndDropUserScriptSettings.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/DragAndDropUserScriptSettings.java
@@ -8,8 +8,8 @@ import org.scijava.widget.FileWidget;
 
 import java.io.File;
 
-@Plugin( type = Command.class, menuPath = "Plugins>OME-Zarr>Preset Drag & Drop User Script", name = "DnDUserScript", headless = true )
-public class PresetScriptPlugin implements Command
+@Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Drag & Drop User Script Settings", name = "OMEZarrDnDUserScript", headless = true )
+public class DragAndDropUserScriptSettings implements Command
 {
 
 	@Parameter( label = "Tooltip text:" )
@@ -24,6 +24,6 @@ public class PresetScriptPlugin implements Command
 	@Override
 	public void run()
 	{
-		log.info( "Thanks, memorizing it now..." );
+		log.info( "Thanks, memorizing the path: " + scriptPath );
 	}
 }

--- a/src/main/java/sc/fiji/ome/zarr/plugins/OpenInBDVCommand.java
+++ b/src/main/java/sc/fiji/ome/zarr/plugins/OpenInBDVCommand.java
@@ -40,7 +40,7 @@ import org.scijava.plugin.Plugin;
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
 import sc.fiji.ome.zarr.util.BdvUtils;
 
-@Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Open Current Zarr Image in BigDataViewer" )
+@Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Open Current OME-Zarr Image in BigDataViewer" )
 public class OpenInBDVCommand implements Command
 {
 	@Parameter

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
@@ -271,7 +271,7 @@ public class DefaultPyramidal5DImageData<
 		{
 			// for the Mipmap, RAIs must always be xyzt even if z and/or t is not present,
 			// but first the particular channel is taken out, and then 4D is ensured:
-			// NB: the input tensor is an ome-zarr array, which is of the xy[z][t][c] order of dimensions,
+			// NB: the input tensor is an OME-Zarr array, which is of the xy[z][t][c] order of dimensions,
 			//     so really only a particular 'c' is extracted, and 'z' and 't' are added if they are missing
 			RandomAccessibleInterval< V >[] channelsVolatile =
 					ensureOrdered4dDimensions( extractChannel( volatileImgs, channelAxisIndex, channelNumber ), zAxisPresent, timeAxisPresent );
@@ -400,7 +400,7 @@ public class DefaultPyramidal5DImageData<
 			throw new IllegalArgumentException( "Input path is null" );
 		Path path = ZarrOnFileSystemUtils.findRootFolder( inputPath );
 		if ( path == null )
-			throw new IllegalArgumentException( "Could not find root folder for non-Zarr path: " + inputPath );
+			throw new IllegalArgumentException( "Could not find root folder for non-OME-Zarr path: " + inputPath );
 		return path;
 	}
 

--- a/src/main/java/sc/fiji/ome/zarr/settings/ZarrDragAndDropOpenSettings.java
+++ b/src/main/java/sc/fiji/ome/zarr/settings/ZarrDragAndDropOpenSettings.java
@@ -91,8 +91,8 @@ public class ZarrDragAndDropOpenSettings
 						ZarrDragAndDropOpenSettings.class, ZARR_PREFERRED_WIDTH_SETTING_NAME,
 						DEFAULT_PREFERRED_WIDTH
 				);
-		logger.debug( "Loaded Zarr default opening behavior: {}", behavior );
-		logger.debug( "Loaded zarr preferred width: {}", preferredWidth );
+		logger.debug( "Loaded OME-Zarr default opening behavior: {}", behavior );
+		logger.debug( "Loaded OME-Zarr preferred width: {}", preferredWidth );
 		return new ZarrDragAndDropOpenSettings( behavior, preferredWidth );
 	}
 
@@ -107,8 +107,8 @@ public class ZarrDragAndDropOpenSettings
 			return;
 		prefs.put( ZarrDragAndDropOpenSettings.class, ZARR_OPEN_BEHAVIOR_SETTING_NAME, getOpenBehavior().name() );
 		prefs.put( ZarrDragAndDropOpenSettings.class, ZARR_PREFERRED_WIDTH_SETTING_NAME, getPreferredMaxWidth() );
-		logger.debug( "Saved zarr default opening behavior to preferences: {}", getOpenBehavior() );
-		logger.debug( "Saved zarr preferred width to preferences: {}", getPreferredMaxWidth() );
+		logger.debug( "Saved OME-Zarr default opening behavior to preferences: {}", getOpenBehavior() );
+		logger.debug( "Saved OME-Zarr preferred width to preferences: {}", getPreferredMaxWidth() );
 	}
 
 	@Override

--- a/src/main/java/sc/fiji/ome/zarr/settings/ZarrOpenBehavior.java
+++ b/src/main/java/sc/fiji/ome/zarr/settings/ZarrOpenBehavior.java
@@ -3,7 +3,7 @@ package sc.fiji.ome.zarr.settings;
 import java.util.NoSuchElementException;
 
 /**
- * Options for opening Zarr datasets in different viewers and resolutions.
+ * Options for opening OME-Zarr datasets in different viewers and resolutions.
  */
 public enum ZarrOpenBehavior
 {

--- a/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
+++ b/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
@@ -165,7 +165,7 @@ public class DnDActionChooser
 
 		// script button
 		String scriptName = ScriptUtils.getTooltipText( context );
-		zarrScript.setToolTipText( "Open OME-Zarr Script:\n\n" + scriptName );
+		zarrScript.setToolTipText( "Open OME-Zarr in user script:\n\n" + scriptName );
 		zarrScript.addActionListener( e -> {
 			dialog.dispose();
 			actions.runScript();

--- a/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
+++ b/src/main/java/sc/fiji/ome/zarr/ui/DnDActionChooser.java
@@ -135,37 +135,37 @@ public class DnDActionChooser
 	private void initBehaviour( final JDialog dialog )
 	{
 
-		// zarr to FIJI importer button
+		// OME-Zarr to FIJI importer button
 		zarrToIJDialog.addActionListener( e -> {
 			dialog.dispose();
 			actions.openImporterDialog();
 		} );
-		zarrToIJDialog.setToolTipText( "Open Zarr/N5 Importer dialog" );
+		zarrToIJDialog.setToolTipText( "Open OME-Zarr/N5 Importer dialog" );
 
-		// zarr to BDV viewer button
+		// OME-Zarr to BDV viewer button
 		zarrToBDVDialog.addActionListener( e -> {
 			dialog.dispose();
 			actions.openViewerDialog();
 		} );
-		zarrToBDVDialog.setToolTipText( "Open Zarr/N5 BDV Viewer dialog" );
+		zarrToBDVDialog.setToolTipText( "Open OME-Zarr/N5 BDV Viewer dialog" );
 
 		// FIJI button
 		zarrIJHighestResolution.addActionListener( e -> {
 			dialog.dispose();
 			actions.openIJWithImage();
 		} );
-		zarrIJHighestResolution.setToolTipText( "Open Zarr/N5 in ImageJ at highest resolution level" );
+		zarrIJHighestResolution.setToolTipText( "Open OME-Zarr in ImageJ at highest resolution level" );
 
 		// BDV button
 		zarrBDVHighestResolution.addActionListener( e -> {
 			dialog.dispose();
 			actions.openBDVWithImage();
 		} );
-		zarrBDVHighestResolution.setToolTipText( "Open Zarr/N5 in BDV at highest resolution level" );
+		zarrBDVHighestResolution.setToolTipText( "Open OME-Zarr in BDV at highest resolution level" );
 
 		// script button
 		String scriptName = ScriptUtils.getTooltipText( context );
-		zarrScript.setToolTipText( "Open Zarr/N5 Script:\n\n" + scriptName );
+		zarrScript.setToolTipText( "Open OME-Zarr Script:\n\n" + scriptName );
 		zarrScript.addActionListener( e -> {
 			dialog.dispose();
 			actions.runScript();
@@ -173,7 +173,7 @@ public class DnDActionChooser
 
 		// help button
 		help.addActionListener( e -> dialog.dispose() );
-		help.setToolTipText( "Help about Zarr/N5 actions" );
+		help.setToolTipText( "Help about OME-Zarr actions" );
 		help.addActionListener( e -> actions.showHelp() );
 
 		setupCloseOnKeyboard( dialog );

--- a/src/main/java/sc/fiji/ome/zarr/ui/ZarrDragAndDropOpenSettingsUI.java
+++ b/src/main/java/sc/fiji/ome/zarr/ui/ZarrDragAndDropOpenSettingsUI.java
@@ -18,7 +18,7 @@ import sc.fiji.ome.zarr.settings.ZarrDragAndDropOpenSettings;
 import sc.fiji.ome.zarr.settings.ZarrOpenBehavior;
 
 /**
- * A FIJI/ImageJ command to select what to do when a zarr image is Drag &amp; Dropped into Fiji.
+ * A FIJI/ImageJ command to select what to do when an OME-Zarr image is Drag &amp; Dropped into Fiji.
  */
 @Plugin( type = Command.class, menuPath = "Plugins > OME-Zarr > Drag & Drop Behavior", initializer = "init" )
 public class ZarrDragAndDropOpenSettingsUI extends DynamicCommand
@@ -41,7 +41,7 @@ public class ZarrDragAndDropOpenSettingsUI extends DynamicCommand
 			+ "</html>";
 
 	@SuppressWarnings( "all" )
-	@Parameter( label = "Default Drag & Drop behavior", description = "Chose the behavior if you drag & drop a zarr image folder into Fiji", initializer = "initZarrOpenBehaviors" )
+	@Parameter( label = "Default Drag & Drop behavior", description = "Chose the behavior if you drag & drop an OME-Zarr image folder into Fiji", initializer = "initZarrOpenBehaviors" )
 	private String defaultZarrOpenBehavior;
 
 	@SuppressWarnings( "all" )
@@ -65,7 +65,7 @@ public class ZarrDragAndDropOpenSettingsUI extends DynamicCommand
 	{
 		settings.setCurrentChoice( ZarrOpenBehavior.getByDescription( defaultZarrOpenBehavior ) );
 		settings.setPreferredMaxWidth( preferredWidth );
-		logger.debug( "Now saving Zarr Drag & Drop settings to user preferences. Behavior: {}, preferredWidth: {}",
+		logger.debug( "Now saving OME-Zarr Drag & Drop settings to user preferences. Behavior: {}, preferredWidth: {}",
 				settings.getOpenBehavior(), preferredWidth );
 		settings.saveSettingsToPreferences( prefService );
 	}

--- a/src/main/java/sc/fiji/ome/zarr/ui/ZarrDragAndDropOpenSettingsUI.java
+++ b/src/main/java/sc/fiji/ome/zarr/ui/ZarrDragAndDropOpenSettingsUI.java
@@ -41,7 +41,7 @@ public class ZarrDragAndDropOpenSettingsUI extends DynamicCommand
 			+ "</html>";
 
 	@SuppressWarnings( "all" )
-	@Parameter( label = "Default Drag & Drop behavior", description = "Chose the behavior if you drag & drop an OME-Zarr image folder into Fiji", initializer = "initZarrOpenBehaviors" )
+	@Parameter( label = "Default Drag & Drop behavior", description = "Choose the behavior if you drag & drop an OME-Zarr image folder into Fiji", initializer = "initZarrOpenBehaviors" )
 	private String defaultZarrOpenBehavior;
 
 	@SuppressWarnings( "all" )

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -87,7 +87,7 @@ public class ScriptUtils
 			}
 			catch ( Exception e )
 			{
-				errorHandler.accept( "Script could not be processed on Zarr dataset. " + "\n\r\n" + "Script path: " + scriptPath + "\n"
+				errorHandler.accept( "Script could not be processed on OME-Zarr dataset. " + "\n\r\n" + "Script path: " + scriptPath + "\n"
 						+ "Dataset path: " + inputPath + "\n\n" + "Error message: " + e.getMessage() );
 				logger.warn(
 						" Something went wrong executing the script: {} on this dataset: {}. Message: {}", scriptPath, inputPath,

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -110,7 +110,7 @@ public class ScriptUtils
 	{
 		return "# RESAVE THIS SCRIPT AND OPEN IN THE MENU\n" +
 				"# Fiji -> Plugins -> OME-Zarr -> Preset DragAndDrop User Script\n" +
-				"# to have this available among the drag-and-drop choices.\n" +
+				"# to have this available among the drag & drop choices.\n" +
 				"# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"\n" +
 				"#@ String path\n" +

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -14,7 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 
-import sc.fiji.ome.zarr.plugins.PresetScriptPlugin;
+import sc.fiji.ome.zarr.plugins.DragAndDropUserScriptSettings;
 
 public class ScriptUtils
 {
@@ -45,8 +45,8 @@ public class ScriptUtils
 		if ( prefService == null )
 			return DEFAULT_SCRIPT_TITLE;
 
-		final String scriptTitle = prefService.get( PresetScriptPlugin.class, "scriptTitle", DEFAULT_SCRIPT_TITLE );
-		final String scriptPath = prefService.get( PresetScriptPlugin.class, "scriptPath", "--none--" );
+		final String scriptTitle = prefService.get( DragAndDropUserScriptSettings.class, "scriptTitle", DEFAULT_SCRIPT_TITLE );
+		final String scriptPath = prefService.get( DragAndDropUserScriptSettings.class, "scriptPath", "--none--" );
 
 		return Files.exists( Paths.get( scriptPath ).toAbsolutePath() ) ? scriptTitle : DEFAULT_SCRIPT_TITLE;
 	}
@@ -70,7 +70,7 @@ public class ScriptUtils
 		}
 
 		//retrieve the path to the preset script
-		final String scriptPath = prefService.get( PresetScriptPlugin.class, "scriptPath", "--none--" );
+		final String scriptPath = prefService.get( DragAndDropUserScriptSettings.class, "scriptPath", "--none--" );
 
 		if ( Files.exists( Paths.get( scriptPath ).toAbsolutePath() ) )
 		{
@@ -109,8 +109,8 @@ public class ScriptUtils
 	static String getTemplate()
 	{
 		return "# RESAVE THIS SCRIPT AND OPEN IN THE MENU\n" +
-				"# Fiji -> Plugins -> OME-Zarr -> Preset DragAndDrop User Script\n" +
-				"# to have this available among the drag & drop choices.\n" +
+				"# Fiji > Plugins > OME-Zarr > Drag & Drop User Script Settings\n" +
+				"# to have this available among the OME-Zarr drag & drop choices.\n" +
 				"# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"\n" +
 				"#@ String path\n" +

--- a/src/main/java/sc/fiji/ome/zarr/util/ZarrOnFileSystemUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ZarrOnFileSystemUtils.java
@@ -54,7 +54,7 @@ public class ZarrOnFileSystemUtils
 	/**
 	 * Determines whether the given path appears to be the root of a Zarr dataset.
 	 * <p>
-	 * The method checks for the presence of well-known Zarr metadata files:
+	 * The method checks for the presence of well-known Zarr (and consequently OME-Zarr) metadata files:
 	 * <ul>
 	 *   <li>{@code .zgroup}, {@code .zattrs} or {@code .zarray} for Zarr v2</li>
 	 *   <li>{@code zarr.json} for Zarr v3</li>
@@ -76,11 +76,11 @@ public class ZarrOnFileSystemUtils
 
 	/**
 	 * Traverses up the folder tree as long as {@link #isZarrFolder(Path)}
-	 * says we are inside a Zarr dataset. The last such folder is returned, which is
+	 * says we are inside an OME-Zarr dataset. The last such folder is returned, which is
 	 * supposed to be the top-level/root folder of the pointed at dataset.
 	 *
-	 * @param somewhereInZarrFolder Pointer (folder) to somewhere inside an OME Zarr.
-	 * @return Root of that OME Zarr, or NULL if the provided path is NOT within an OME Zarr.
+	 * @param somewhereInZarrFolder Pointer (folder) to somewhere inside an OME-Zarr.
+	 * @return Root of that OME-Zarr, or NULL if the provided path is NOT within an OME-Zarr.
 	 */
 	public static Path findRootFolder( final Path somewhereInZarrFolder )
 	{
@@ -97,24 +97,24 @@ public class ZarrOnFileSystemUtils
 	}
 
 	/**
-	 * Attempts to locate the root image folder for a given starting path within a Zarr dataset.
+	 * Attempts to locate the root image folder for a given starting path within a OME-Zarr dataset.
 	 * <p>
 	 * The method works as follows:
 	 * <ol>
 	 *     <li>Starts at the given {@code startingFolder} and traverses upward through parent folders
-	 *     as long as each folder qualifies as a Zarr folder according to {@link #isZarrFolder(Path)}.</li>
-	 *     <li>The top-most Zarr folder found is considered the "top-level Zarr folder".</li>
-	 *     <li>If a folder below the top-level Zarr folder was visited during traversal, it is returned
+	 *     as long as each folder qualifies as a OME-Zarr folder according to {@link #isZarrFolder(Path)}.</li>
+	 *     <li>The top-most OME-Zarr folder found is considered the "top-level OME-Zarr folder".</li>
+	 *     <li>If a folder below the top-level OME-Zarr folder was visited during traversal, it is returned
 	 *     as the image folder.</li>
-	 *     <li>If no such folder exists, the method inspects the top-level Zarr folder. If it contains
+	 *     <li>If no such folder exists, the method inspects the top-level OME-Zarr folder. If it contains
 	 *     <b>exactly one</b> subfolder (excluding any folder named "OME"), that subfolder is returned as
 	 *     the image folder.</li>
 	 *     <li>If no suitable candidate folder is found or an I/O error occurs while listing subfolders,
 	 *     the method returns {@code null}.</li>
 	 * </ol>
 	 *
-	 * @param startingFolder the folder path somewhere within a Zarr dataset to start the search from; must not be {@code null}
-	 * @return the path to the candidate image folder below the top-level Zarr folder, or {@code null} if no suitable folder is found
+	 * @param startingFolder the folder path somewhere within a OME-Zarr dataset to start the search from; must not be {@code null}
+	 * @return the path to the candidate image folder below the top-level OME-Zarr folder, or {@code null} if no suitable folder is found
 	 */
 	public static Path findImageRootFolder( final Path startingFolder )
 	{
@@ -122,23 +122,23 @@ public class ZarrOnFileSystemUtils
 		Path topLevelZarrFolder = null;
 		Path imageFolder = null;
 
-		// Traverse up the folder tree as long as we're inside a Zarr folder
+		// Traverse up the folder tree as long as we're inside a OME-Zarr folder
 		while ( isZarrFolder( currentFolder ) )
 		{
-			imageFolder = topLevelZarrFolder; // last visited folder just below potential top-level Zarr
+			imageFolder = topLevelZarrFolder; // last visited folder just below potential top-level OME-Zarr
 			topLevelZarrFolder = currentFolder;
 			currentFolder = currentFolder.getParent();
 		}
 
-		// If no Zarr folder was ever found
+		// If no OME-Zarr folder was ever found
 		if ( topLevelZarrFolder == null )
 			return null;
 
-		// If there was a folder below top-level Zarr while traversing up, return it
+		// If there was a folder below top-level OME-Zarr while traversing up, return it
 		if ( imageFolder != null )
 			return imageFolder;
 
-		// Otherwise, check if top-level Zarr has only one suitable subfolder
+		// Otherwise, check if top-level OME-Zarr has only one suitable subfolder
 		try (Stream< Path > stream = Files.list( topLevelZarrFolder ))
 		{
 			Path[] subFolders = stream

--- a/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
@@ -126,7 +126,7 @@ public class ZarrOpenActions
 	private void showNonMatchingResolutionError( final Exception e )
 	{
 		errorHandler.accept( "Safety check failed when opening dataset: " + droppedInPath + "\n\r\n" + e.getMessage() + "\n\r\n"
-				+ "If the image size is okay for this computer, please adjust the setting in\nPlugins > OME-Zarr > OME-Zarr Drag And Drop Open Settings to still open the image." );
+				+ "If the image size is okay for this computer, please adjust the setting in\nPlugins > OME-Zarr > Drag & Drop Behavior Settings to still open the image." );
 		logger.warn( "Not opening dataset: {}. Error message: {}", droppedInPath, e.getMessage() );
 	}
 

--- a/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
@@ -119,14 +119,14 @@ public class ZarrOpenActions
 	private void showNonZarrError( final Exception e )
 	{
 		errorHandler.accept( "Could not open dataset as image: " + droppedInPath + "\n\n"
-				+ "The drag & drop for Zarr folders only supports folders that contains zarr metadata, i.e. .zattrs, .zgroup, or zarr.json files." );
+				+ "The drag & drop for OME-Zarr folders only supports folders that contains OME-Zarr metadata, i.e. .zattrs, .zgroup, or zarr.json files." );
 		logger.warn( "Could not open dataset image: {}. Error message: {}", droppedInPath, e.getMessage() );
 	}
 
 	private void showNonMatchingResolutionError( final Exception e )
 	{
 		errorHandler.accept( "Safety check failed when opening dataset: " + droppedInPath + "\n\r\n" + e.getMessage() + "\n\r\n"
-				+ "If the image size is okay for this computer, please adjust the setting in\nPlugins > OME-Zarr > Zarr Drag And Drop Open Settings to still open the image." );
+				+ "If the image size is okay for this computer, please adjust the setting in\nPlugins > OME-Zarr > OME-Zarr Drag And Drop Open Settings to still open the image." );
 		logger.warn( "Not opening dataset: {}. Error message: {}", droppedInPath, e.getMessage() );
 	}
 

--- a/src/test/java/sc/fiji/ome/zarr/plugins/DragAndDropBehaviorSettingsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/plugins/DragAndDropBehaviorSettingsTest.java
@@ -1,4 +1,4 @@
-package sc.fiji.ome.zarr.ui;
+package sc.fiji.ome.zarr.plugins;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,10 +14,10 @@ import sc.fiji.ome.zarr.settings.ZarrDragAndDropOpenSettings;
 import sc.fiji.ome.zarr.settings.ZarrOpenBehavior;
 
 /**
- * Unit tests for the {@link ZarrDragAndDropOpenSettingsUI#run()} method.
+ * Unit tests for the {@link DragAndDropBehaviorSettings#run()} method.
  * This method is responsible for saving user preferences for Zarr dataset opening behavior.
  */
-class ZarrDragAndDropOpenSettingsUITest
+class DragAndDropBehaviorSettingsTest
 {
 
 	@Test
@@ -26,24 +26,24 @@ class ZarrDragAndDropOpenSettingsUITest
 	{
 		try (Context context = new Context())
 		{
-			ZarrDragAndDropOpenSettingsUI ui = new ZarrDragAndDropOpenSettingsUI();
+			DragAndDropBehaviorSettings ui = new DragAndDropBehaviorSettings();
 			PrefService prefService = context.getService( PrefService.class );
 			prefService.clearAll();
 			final int customWidth = 500;
 
-			Field prefServiceField = ZarrDragAndDropOpenSettingsUI.class.getDeclaredField( "prefService" );
+			Field prefServiceField = DragAndDropBehaviorSettings.class.getDeclaredField( "prefService" );
 			prefServiceField.setAccessible( true );
 			prefServiceField.set( ui, prefService );
 
-			Method initMethod = ZarrDragAndDropOpenSettingsUI.class.getDeclaredMethod( "init" );
+			Method initMethod = DragAndDropBehaviorSettings.class.getDeclaredMethod( "init" );
 			initMethod.setAccessible( true ); // bypasses private visibility
 			initMethod.invoke( ui );
 
-			Field defaultZarrOpenBehaviorField = ZarrDragAndDropOpenSettingsUI.class.getDeclaredField( "defaultZarrOpenBehavior" );
+			Field defaultZarrOpenBehaviorField = DragAndDropBehaviorSettings.class.getDeclaredField( "defaultZarrOpenBehavior" );
 			defaultZarrOpenBehaviorField.setAccessible( true );
 			defaultZarrOpenBehaviorField.set( ui, ZarrOpenBehavior.IMAGEJ_HIGHEST_RESOLUTION.getDescription() );
 
-			Field preferredWidthField = ZarrDragAndDropOpenSettingsUI.class.getDeclaredField( "preferredWidth" );
+			Field preferredWidthField = DragAndDropBehaviorSettings.class.getDeclaredField( "preferredWidth" );
 			preferredWidthField.setAccessible( true );
 			preferredWidthField.set( ui, customWidth );
 

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -44,7 +44,7 @@ import javax.swing.SwingUtilities;
 
 import bdv.viewer.ViewerFrame;
 import bdv.util.BdvStackSource;
-import sc.fiji.ome.zarr.plugins.PresetScriptPlugin;
+import sc.fiji.ome.zarr.plugins.DragAndDropUserScriptSettings;
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
 import sc.fiji.ome.zarr.settings.ZarrDragAndDropOpenSettings;
 import sc.fiji.ome.zarr.settings.ZarrOpenBehavior;
@@ -271,7 +271,7 @@ class ZarrOpenActionsTest
 			try (Context context = new Context())
 			{
 				PrefService prefService = context.getService( PrefService.class );
-				prefService.put( PresetScriptPlugin.class, "scriptPath", "--none--" );
+				prefService.put( DragAndDropUserScriptSettings.class, "scriptPath", "--none--" );
 				String resource = "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr";
 				Path path = ZarrTestUtils.resourcePath( resource );
 				ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );
@@ -313,7 +313,7 @@ class ZarrOpenActionsTest
 
 			File tempFile = temp.toFile();
 			tempFile.deleteOnExit();
-			prefService.put( PresetScriptPlugin.class, "scriptPath", tempFile.getAbsolutePath() );
+			prefService.put( DragAndDropUserScriptSettings.class, "scriptPath", tempFile.getAbsolutePath() );
 			String resource = "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr";
 			Path path = ZarrTestUtils.resourcePath( resource );
 			ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );


### PR DESCRIPTION
:point_right: This PR depends on PR #47 (since it fixes a spelling in that code as well) and must wait for it first.
After #47 is merged, this one would need to be rebased against main, I think.

---

## OME-Zarr is the only spelling in the project

Based on several checks for patterns like `\<[zA]arr\>` (single word), `-i OME` (case ignored), 
all highlighted places of occurrence were manually inspected, and potentially fixed.

Care was taken that the proper format of writing is `OME-Zarr`, with the dash, upper
case `OME` and `Z`.

The aim was to make sure that reporting towards user (console messages, error reports,
notification windows, etc.) leaves no doubt that only OME-Zarr is meant and supported
(and not pure Zarr, without the OME extension).

Code documentation was alterted towards this as well. Exception, however, remains in
the function `util/ZarrOnFileSystemUtils.java#isZarrFolder()`, which indeed detects/recognizes
also pure Zarr datasets.

## Additional changes:

- Similarly, the spelling of DnD has been checked to be `drag & drop` in reports, `Drag & Drop` in titles.
- The "user script setting" plugin has been named/titled similarly to the Behavior settings plugin.
- The `ZarrDragAndDropOpenSettingsUI` class was moved to `plugins` package and renamed to `DragAndDropBehaviorSettings`
  (as it is clear from the package path that it cares about zarr, and it's a UI thing -- hence both words were dropped).
