### PR TITLE
Add maven central secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,4 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASS: ${{ secrets.MAVEN_PASS }}
-          OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
           SIGNING_ASC: ${{ secrets.SIGNING_ASC }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Execute the build
         run: .github/build.sh
         env:
+          CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
           GPG_KEY_NAME: ${{ secrets.GPG_KEY_NAME }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           MAVEN_USER: ${{ secrets.MAVEN_USER }}


### PR DESCRIPTION
This pull request updates the build workflow to set `CENTRAL_USER` and `CENTRAL_PASS` secrets.

The motivation behind this is the failing build job, when trying to deploy a release: https://github.com/BioImageTools/ome-zarr-fiji-java/actions/runs/23899823170/job/69693320163

The `OSSRH_PASS` is removed, since it is unused.

Build workflow authentication updates:

* Updated `.github/workflows/build.yml` to add `CENTRAL_USER` and `CENTRAL_PASS` as environment variables and remove `OSSRH_PASS` from the build step, aligning credential usage with the current deployment requirements.