### PR TITLE
Change mvn build profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,12 +194,17 @@
 		<!-- ====================================== -->
 		<!-- test dependencies -->
 		<!-- ====================================== -->
-
-		<!-- for testing/development purposes: include imagej-legacy at test runtime -->
+		<!-- for testing/development purposes: include imagej at test runtime -->
 		<dependency>
-			<groupId>net.imagej</groupId>
-			<artifactId>imagej</artifactId>
+			<groupId>sc.fiji</groupId>
+			<artifactId>fiji</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>net.imagej</groupId>
+					<artifactId>imagej-legacy</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- for testing/development purposes: include logback-classic at test runtime -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -303,18 +303,5 @@
 				</plugins>
 			</build>
 		</profile>
-		<profile>
-			<id>ui-tests</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>sc.fiji</groupId>
-					<artifactId>fiji</artifactId>
-					<scope>provided</scope> <!-- added to test runtime only when profile active -->
-				</dependency>
-			</dependencies>
-		</profile>
 	</profiles>
 </project>

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -529,6 +529,9 @@ class ZarrOpenActionsTest
 			}
 			assertFalse( foundTextEditor, "TextEditor window should not be open" );
 			assertTrue( foundBigDataViewer, "BigDataViewer window should be open" );
+
+			for ( Window window : Window.getWindows() )
+				window.dispose();
 		}
 	}
 }


### PR DESCRIPTION
This PR updates test dependencies. Test dependencies are changed from `imagej` to `fiji` (excluding `imagej-legacy`)
The maven profile `ui-tests` is removed, since it is not needed anymore.
Extra to this it is ensured all windows are disposed at the end of `testRunScriptWithScriptSpecified` in `ZarrOpenActionsTest.java`.


This PR became possible, since the Java heap space error observed on Macos earlier when running lots of unit tests in a row could be narrowed down to the simulatanoues existence of `scijava-common` and `imagej-legacy`: https://github.com/fiji/fiji/issues/427#issuecomment-4178009760

Ideally should only be merged after https://github.com/BioImageTools/ome-zarr-fiji-java/pull/59 has been merged to allow testing this on macos in the ci pipeline.