### PR TITLE
Fix bug while running scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,12 +199,6 @@
 			<groupId>sc.fiji</groupId>
 			<artifactId>fiji</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>net.imagej</groupId>
-					<artifactId>imagej-legacy</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<!-- for testing/development purposes: include logback-classic at test runtime -->
 		<dependency>

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -107,6 +107,7 @@ public class ScriptUtils
 			try
 			{
 				ScriptModule module = scriptService.getScript( new File( scriptPath ) ).createModule();
+				module.setContext( ctx );
 				module.setInput( "path", inputPath );
 				logger.info( "Executing script: {}", scriptPath );
 				logger.info( "on String parameter: {}", inputPath );

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -129,7 +129,7 @@ public class ScriptUtils
 		}
 		else
 		{
-			logger.debug( "Script path is not valid: {}. Opening script editor with template.", scriptPath );
+			logger.info( "Script path is not valid: {}. Opening script editor with a script template instead.", scriptPath );
 			//this opens an _always new_ window with the template script,
 			//...at least the user is more likely to notice that this "help" came up
 			final TextEditor editor = new TextEditor( ctx );

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -130,6 +130,8 @@ public class ScriptUtils
 		else
 		{
 			logger.info( "Script path is not valid: {}. Opening script editor with a script template instead.", scriptPath );
+			errorHandler.accept( "Script path is not valid: " + scriptPath
+					+ ".\n\nPlease provide a valid path via Plugins Plugins > OME-Zarr > Drag & Drop User Script Settings.\n\nWill open now script editor with a script template." );
 			//this opens an _always new_ window with the template script,
 			//...at least the user is more likely to notice that this "help" came up
 			final TextEditor editor = new TextEditor( ctx );

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -93,9 +93,9 @@ public class ScriptUtils
 		PrefService prefService = ctx.getService( PrefService.class );
 		if ( scriptService == null || prefService == null )
 		{
+			logger.error( "Failed obtaining Script and/or Pref services. Is Fiji properly initiated?" );
 			errorHandler.accept(
 					"Service for running scripts and/or service for reading preferences are not available. Is Fiji properly initiated?" );
-			logger.error( "Failed obtaining Script and/or Pref services. Is Fiji properly initiated?" );
 			return;
 		}
 

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -115,12 +115,13 @@ public class ScriptUtils
 			}
 			catch ( Exception e )
 			{
-				errorHandler.accept( "Script could not be processed on OME-Zarr dataset. " + "\n\r\n" + "Script path: " + scriptPath + "\n"
-						+ "Dataset path: " + inputPath + "\n\n" + "Error message: " + e.getMessage() );
 				logger.warn(
 						" Something went wrong executing the script: {} on this dataset: {}. Message: {}", scriptPath, inputPath,
 						e.getMessage()
 				);
+				errorHandler.accept( "Script could not be processed on OME-Zarr dataset. " + "\n\r\n" + "Script path: " + scriptPath + "\n"
+						+ "Dataset path: " + inputPath + "\n\n" + "Error message: " + e.getMessage() );
+
 			}
 		}
 		else

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -93,6 +93,8 @@ public class ScriptUtils
 		PrefService prefService = ctx.getService( PrefService.class );
 		if ( scriptService == null || prefService == null )
 		{
+			errorHandler.accept(
+					"Service for running scripts and/or service for reading preferences are not available. Is Fiji properly initiated?" );
 			logger.error( "Failed obtaining Script and/or Pref services. Is Fiji properly initiated?" );
 			return;
 		}

--- a/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ScriptUtils.java
@@ -131,7 +131,7 @@ public class ScriptUtils
 		{
 			logger.info( "Script path is not valid: {}. Opening script editor with a script template instead.", scriptPath );
 			errorHandler.accept( "Script path is not valid: " + scriptPath
-					+ ".\n\nPlease provide a valid path via Plugins Plugins > OME-Zarr > Drag & Drop User Script Settings.\n\nWill open now script editor with a script template." );
+					+ ".\n\nPlease provide a valid path via Plugins > OME-Zarr > Drag & Drop User Script Settings.\n\nWill open now script editor with a script template." );
 			//this opens an _always new_ window with the template script,
 			//...at least the user is more likely to notice that this "help" came up
 			final TextEditor editor = new TextEditor( ctx );

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -62,7 +62,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -507,7 +509,12 @@ class ZarrOpenActionsTest
 			prefService.put( DragAndDropUserScriptSettings.class, "scriptPath", tempFile.getAbsolutePath() );
 			String resource = "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr";
 			Path path = ZarrTestUtils.resourcePath( resource );
-			ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );
+			AtomicBoolean scriptFailed = new AtomicBoolean( false );
+			Consumer< String > errorHandler = errorMessage -> {
+				scriptFailed.set( true );
+				System.out.println( errorMessage );
+			};
+			ZarrOpenActions actions = new ZarrOpenActions( path, context, null, errorHandler );
 			actions.runScript();
 
 			boolean foundTextEditor = false;
@@ -530,6 +537,7 @@ class ZarrOpenActionsTest
 			}
 			assertFalse( foundTextEditor, "TextEditor window should not be open" );
 			assertTrue( foundBigDataViewer, "BigDataViewer window should be open" );
+			assertFalse( scriptFailed.get(), "Script should not have failed" );
 
 			for ( Window window : Window.getWindows() )
 				window.dispose();

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -467,7 +467,12 @@ class ZarrOpenActionsTest
 				prefService.put( DragAndDropUserScriptSettings.class, "scriptPath", "--none--" );
 				String resource = "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr";
 				Path path = ZarrTestUtils.resourcePath( resource );
-				ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );
+				AtomicBoolean scriptFailed = new AtomicBoolean( false );
+				Consumer< String > errorHandler = errorMessage -> {
+					scriptFailed.set( true );
+					System.out.println( errorMessage );
+				};
+				ZarrOpenActions actions = new ZarrOpenActions( path, context, null, errorHandler );
 				actions.runScript();
 
 				// wait until all Swing events are processed
@@ -487,6 +492,7 @@ class ZarrOpenActionsTest
 					}
 				}
 				assertTrue( found, "TextEditor window should be open" );
+				assertTrue( scriptFailed.get(), "Script should fail" );
 				assertEquals( ScriptUtils.getTemplate(), text );
 			}
 		}

--- a/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/util/ZarrOpenActionsTest.java
@@ -278,8 +278,9 @@ class ZarrOpenActionsTest
 		Path path = ZarrTestUtils.resourcePath( resource );
 		try (Context context = new Context())
 		{
-			ZarrOpenActions actions = new ZarrOpenActions( path, context );
+			ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );
 			ImagePlus imagePlus = Cast.unchecked( actions.openIJWithImage() );
+			assertNotNull( imagePlus );
 			int channels = imagePlus.getNChannels();
 			int frames = imagePlus.getNFrames();
 			int slices = imagePlus.getNSlices();
@@ -391,7 +392,7 @@ class ZarrOpenActionsTest
 		Path path = ZarrTestUtils.resourcePath( resource );
 		try (Context context = new Context())
 		{
-			ZarrOpenActions actions = new ZarrOpenActions( path, context );
+			ZarrOpenActions actions = new ZarrOpenActions( path, context, null, System.out::println );
 			BdvStackSource< ? > bdvStackSource = Cast.unchecked( actions.openBDVWithImage() );
 			DatasetService datasetService = context.getService( DatasetService.class );
 			assertNotNull( datasetService );


### PR DESCRIPTION
This PR fixes a bug that occured when running scripts on imported OME-Zarrs

**Error handling and messaging improvements:**

* Added explicit error messages when required services (`ScriptService` or `PrefService`) are unavailable, clarifying potential issues with Fiji initialization (`ScriptUtils.java`).

**Script execution robustness:**

* Ensured that the `ScriptModule` context is explicitly set before script execution, which is important for proper script functioning within the Fiji environment (`ScriptUtils.java`).

**Testing enhancements:**

* Updated tests to check for script failures, improving test reliability and coverage of error scenarios (`ZarrOpenActionsTest.java`).
* Modified test setup for single scale image opening methods (actually unrelated to the bug)

**Dependency management:**

* Removed unnecessary exclusions from the `fiji` test dependency in `pom.xml`, since the Java heap space error is not occurring any longer.