### PR TITLE
Refactor DefaultPyramidal5DImageData class

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -46,8 +46,6 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Cast;
 import net.imglib2.view.Views;
 
-import org.janelia.saalfeldlab.n5.DataType;
-import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5DatasetDiscoverer;
@@ -55,7 +53,6 @@ import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5MetadataParser;
-import org.janelia.saalfeldlab.n5.universe.metadata.N5SingleScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.SpatialMetadataGroup;
 import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
 import org.scijava.Context;
@@ -73,9 +70,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-
 import bdv.BigDataViewer;
 import bdv.cache.SharedQueue;
 import bdv.util.RandomAccessibleIntervalMipmapSource4D;
@@ -84,7 +78,11 @@ import bdv.util.volatiles.VolatileViews;
 import bdv.viewer.SourceAndConverter;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
+import sc.fiji.ome.zarr.pyramid.metadata.ResolutionLevel;
+import sc.fiji.ome.zarr.pyramid.metadata.adapter.MetadataAdapter;
+import sc.fiji.ome.zarr.pyramid.metadata.adapter.MetadataAdapterFactory;
 import sc.fiji.ome.zarr.util.Affine3DUtils;
 import sc.fiji.ome.zarr.util.ZarrOnFileSystemUtils;
 
@@ -226,7 +224,7 @@ public class DefaultPyramidal5DImageData<
 		this.volatileType = Cast.unchecked( VolatileTypeMatcher.getVolatileTypeForType( type ) );
 		this.name = multiscale.getName();
 		this.numResolutionLevels = multiscale.numResolutionLevels();
-		this.numDimensions = resolutionLevel.attributes.getDimensions().length;
+		this.numDimensions = resolutionLevel.getAttributes().getDimensions().length;
 		this.numTimepoints = getNumTimepointsFromResolutionLevel( resolutionLevel );
 		this.numChannels = getNumChannelsFromResolutionLevel( resolutionLevel );
 
@@ -235,10 +233,10 @@ public class DefaultPyramidal5DImageData<
 		volatileImgs = Cast.unchecked( new RandomAccessibleInterval[ numResolutionLevels ] );
 		for ( ResolutionLevel level : multiscale.getLevels() )
 		{
-			cachedCellImgs[ level.index ] = N5Utils.openVolatile( reader, level.datasetPath );
-			volatileImgs[ level.index ] = VolatileViews.wrapAsVolatile( cachedCellImgs[ level.index ], sharedQueue );
+			cachedCellImgs[ level.getIndex() ] = N5Utils.openVolatile( reader, level.getDatasetPath() );
+			volatileImgs[ level.getIndex() ] = VolatileViews.wrapAsVolatile( cachedCellImgs[ level.getIndex() ], sharedQueue );
 		}
-		final ImgPlus< T > imgPlus = new ImgPlus<>( cachedCellImgs[ resolutionLevel.index ], name );
+		final ImgPlus< T > imgPlus = new ImgPlus<>( cachedCellImgs[ resolutionLevel.getIndex() ], name );
 		configureImgPlusAxesFromResolutionLevel( imgPlus, resolutionLevel );
 
 		this.ijDataset = new DefaultDataset( context, imgPlus );
@@ -436,240 +434,29 @@ public class DefaultPyramidal5DImageData<
 		return n5Metadata;
 	}
 
-	private static class Multiscale
-	{
-
-		private final String name;
-
-		private final List< ResolutionLevel > resolutionLevels;
-
-		private final DataType dataType;
-
-		private Multiscale( final String name, final List< ResolutionLevel > resolutionLevels, final DataType dataType )
-		{
-			this.name = name;
-			this.resolutionLevels = resolutionLevels;
-			this.dataType = dataType;
-		}
-
-		public String getName()
-		{
-			return name;
-		}
-
-		public int numResolutionLevels()
-		{
-			return resolutionLevels.size();
-		}
-
-		public List< ResolutionLevel > getLevels()
-		{
-			return resolutionLevels;
-		}
-
-		public DataType getDataType()
-		{
-			return dataType;
-		}
-	}
-
-	// ---------------------------------------------------------------------
-	// Selected Scale Level Representation
-	// ---------------------------------------------------------------------
-
-	private static class ResolutionLevel
-	{
-		private final String datasetPath;
-
-		private final int index; // the position of the resolution level within a multiscale object
-
-		private final DatasetAttributes attributes;
-
-		private final Axis[] axes; // for OME NGFF v04 metadata
-
-		private final String[] axisNames; // for OME NGFF v03 metadata
-
-		private final String[] units; // for OME NGFF v03 metadata
-
-		private final double[] scales; // down sampling factor
-
-		private ResolutionLevel(
-				final String datasetPath, final int index, final DatasetAttributes attributes, final Axis[] axes, final String[] axisNames,
-				final String[] units, final double[] scales )
-		{
-			this.datasetPath = datasetPath;
-			this.index = index;
-			this.attributes = attributes;
-			this.axes = axes;
-			this.axisNames = axisNames;
-			this.units = units;
-			this.scales = scales;
-		}
-	}
-
-	// ---------------------------------------------------------------------
-	// Metadata Adapter Strategy
-	// ---------------------------------------------------------------------
-
-	private interface MetadataAdapter
-	{
-		Multiscale initMultiscale( final N5Metadata metadata, final int multiscaleIndex );
-
-		Omero initOmeroMetadata();
-	}
-
-	private abstract static class AbstractMetadataAdapter implements MetadataAdapter
-	{
-		protected final N5Reader reader;
-
-		protected final N5TreeNode node;
-
-		public AbstractMetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			this.reader = reader;
-			this.node = node;
-		}
-
-		protected Multiscale buildMultiscale( final String name,
-				final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.NgffSingleScaleAxesMetadata[] children )
-		{
-			final List< ResolutionLevel > levels = new ArrayList<>();
-			int index = 0;
-			for ( org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.NgffSingleScaleAxesMetadata single : children )
-			{
-				levels.add( new ResolutionLevel( single.getPath(), index++, single.getAttributes(), single.getAxes(), null, null,
-						single.getScale() ) );
-			}
-			return new Multiscale( name, levels, children[ 0 ].getAttributes().getDataType()
-			);
-		}
-
-		@Override
-		public Omero initOmeroMetadata()
-		{
-			final JsonElement base = reader.getAttribute( node.getPath(), getOmeroKey(), JsonElement.class );
-			return new Gson().fromJson( base, Omero.class );
-		}
-
-		protected abstract String getOmeroKey();
-	}
-
-	private static class MetadataAdapterFactory
-	{
-		static MetadataAdapter getAdapter( final N5Metadata metadata, final N5Reader reader, final N5TreeNode node )
-		{
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata )
-				return new V05MetadataAdapter( reader, node );
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata )
-				return new V04MetadataAdapter( reader, node );
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata )
-				return new V03MetadataAdapter( reader, node );
-			throw new NotAMultiscaleImageException(
-					"Unsupported multiscale metadata type: " + metadata.getClass() );
-		}
-	}
-
-	private static class V05MetadataAdapter extends AbstractMetadataAdapter
-	{
-		private V05MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata omeNgffMetadata = Cast.unchecked( n5Metadata );
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata multiscales =
-					omeNgffMetadata.multiscales[ multiscaleIndex ]; // NB: v04 multi scale metadata ??
-			return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "ome/omero";
-		}
-	}
-
-	private static class V04MetadataAdapter extends AbstractMetadataAdapter
-	{
-		private V04MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata multiscales = omeNgffMetadata.multiscales[ multiscaleIndex ];
-			if ( multiscales.getChildrenMetadata().length == 0 || multiscales.getChildrenMetadata()[ 0 ] == null )
-				throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children attributes." );
-			return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "omero";
-		}
-	}
-
-	private static class V03MetadataAdapter extends AbstractMetadataAdapter
-	{
-		private V03MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
-			org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMultiScaleMetadata multiscales =
-					omeNgffMetadata.getMultiscales()[ multiscaleIndex ];
-			if ( multiscales.getChildrenMetadata() == null || multiscales.getChildrenMetadata().length == 0 )
-				throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children metadata." );
-			final List< ResolutionLevel > levels = new ArrayList<>();
-			int index = 0;
-			for ( N5SingleScaleMetadata single : multiscales.getChildrenMetadata() )
-			{
-				levels.add(
-						new ResolutionLevel( single.getPath(), index++, single.getAttributes(), null, multiscales.axes, multiscales.units(),
-						single.getPixelResolution() ) );
-			}
-			return new Multiscale( multiscales.name, levels, multiscales.getChildrenMetadata()[ 0 ].getAttributes().getDataType() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "omero";
-		}
-	}
-
 	// ---------------------------------------------------------------------
 	// Axis Configuration
 	// ---------------------------------------------------------------------
 
 	private void configureImgPlusAxesFromResolutionLevel( final ImgPlus< T > img, final ResolutionLevel resolutionLevel )
 	{
-		if ( resolutionLevel.axes != null )
+		final Axis[] axes = resolutionLevel.getAxes();
+		final String[] axisNames = resolutionLevel.getAxisNames();
+		final double[] scales = resolutionLevel.getScales();
+		if ( axes != null )
 		{
-			for ( int i = 0; i < resolutionLevel.axes.length; i++ )
+			for ( int i = 0; i < axes.length; i++ )
 			{
-				Axis axis = resolutionLevel.axes[ i ];
-				setImgPlusAxis( img, AXIS_MAPPING.get( axis.getName() ), axis.getUnit(), resolutionLevel.scales[ i ], i );
+				Axis axis = axes[ i ];
+				setImgPlusAxis( img, AXIS_MAPPING.get( axis.getName() ), axis.getUnit(), scales[ i ], i );
 			}
 		}
-		else if ( resolutionLevel.axisNames != null )
+		else if ( axisNames != null )
 		{
-			for ( int i = 0; i < resolutionLevel.axisNames.length; i++ )
+			final String[] units = resolutionLevel.getUnits();
+			for ( int i = 0; i < axisNames.length; i++ )
 			{
-				setImgPlusAxis( img, AXIS_MAPPING.get( resolutionLevel.axisNames[ i ] ), resolutionLevel.units[ i ],
-						resolutionLevel.scales[ i ],
-						i );
+				setImgPlusAxis( img, AXIS_MAPPING.get( axisNames[ i ] ), units[ i ], scales[ i ], i );
 			}
 		}
 	}
@@ -693,25 +480,28 @@ public class DefaultPyramidal5DImageData<
 	{
 		final int axisIndex = findAxisIndex( resolutionLevel, axisType );
 
-		return axisIndex >= 0 ? ( int ) resolutionLevel.attributes.getDimensions()[ axisIndex ] : 1;
+		return axisIndex >= 0 ? ( int ) resolutionLevel.getAttributes().getDimensions()[ axisIndex ] : 1;
 	}
 
 	private int findAxisIndex( final ResolutionLevel resolutionLevel, final AxisType axisType )
 	{
-		if ( resolutionLevel.axes != null )
+		final Axis[] axes = resolutionLevel.getAxes();
+		if ( axes != null )
 		{
-			for ( int i = 0; i < resolutionLevel.axes.length; i++ )
+			for ( int i = 0; i < axes.length; i++ )
 			{
-				Axis axis = resolutionLevel.axes[ i ];
+				Axis axis = axes[ i ];
 				if ( axisType.equals( AXIS_MAPPING.get( axis.getName() ) ) )
 					return i;
 			}
+			return -1;
 		}
-		else if ( resolutionLevel.axisNames != null )
+		final String[] axisNames = resolutionLevel.getAxisNames();
+		if ( axisNames != null )
 		{
-			for ( int i = 0; i < resolutionLevel.axisNames.length; i++ )
+			for ( int i = 0; i < axisNames.length; i++ )
 			{
-				if ( axisType.equals( AXIS_MAPPING.get( resolutionLevel.axisNames[ i ] ) ) )
+				if ( axisType.equals( AXIS_MAPPING.get( axisNames[ i ] ) ) )
 					return i;
 			}
 		}
@@ -786,7 +576,7 @@ public class DefaultPyramidal5DImageData<
 	}
 
 	@Override
-	public String getName()
+public String getName()
 	{
 		return name;
 	}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
@@ -78,6 +78,8 @@ import bdv.util.volatiles.VolatileViews;
 import bdv.viewer.SourceAndConverter;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
+import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 import sc.fiji.ome.zarr.pyramid.metadata.ResolutionLevel;

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NoMatchingResolutionException.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NoMatchingResolutionException.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package sc.fiji.ome.zarr.pyramid;
+package sc.fiji.ome.zarr.pyramid.exceptions;
 
 public class NoMatchingResolutionException extends RuntimeException
 {

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NotAMultiscaleImageException.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NotAMultiscaleImageException.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package sc.fiji.ome.zarr.pyramid;
+package sc.fiji.ome.zarr.pyramid.exceptions;
 
 public class NotAMultiscaleImageException extends RuntimeException
 {

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NotASingleScaleImageException.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/NotASingleScaleImageException.java
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-package sc.fiji.ome.zarr.pyramid;
+package sc.fiji.ome.zarr.pyramid.exceptions;
 
 public class NotASingleScaleImageException extends RuntimeException
 {

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/Multiscale.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/Multiscale.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata;
+
+import java.util.List;
+
+import org.janelia.saalfeldlab.n5.DataType;
+
+/**
+ * A named pyramid of {@link ResolutionLevel}s sharing a single pixel
+ * {@link DataType}. Index 0 is the highest resolution per the OME-Zarr spec.
+ */
+public class Multiscale
+{
+	private final String name;
+
+	private final List< ResolutionLevel > resolutionLevels;
+
+	private final DataType dataType;
+
+	public Multiscale( final String name, final List< ResolutionLevel > resolutionLevels, final DataType dataType )
+	{
+		this.name = name;
+		this.resolutionLevels = resolutionLevels;
+		this.dataType = dataType;
+	}
+
+	public String getName()
+	{
+		return name;
+	}
+
+	public int numResolutionLevels()
+	{
+		return resolutionLevels.size();
+	}
+
+	public List< ResolutionLevel > getLevels()
+	{
+		return resolutionLevels;
+	}
+
+	public DataType getDataType()
+	{
+		return dataType;
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/ResolutionLevel.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/ResolutionLevel.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata;
+
+import org.janelia.saalfeldlab.n5.DatasetAttributes;
+import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
+
+/**
+ * One entry in a multiscale pyramid: the dataset path, its position in the
+ * pyramid, and the axis/scale metadata needed to describe it.
+ * <p>
+ * Holds either {@link Axis} entries (OME-NGFF v04/v05) <em>or</em> axis names
+ * and units as separate arrays (OME-NGFF v03).
+ */
+public class ResolutionLevel
+{
+	private final String datasetPath;
+
+	private final int index;
+
+	private final DatasetAttributes attributes;
+
+	private final Axis[] axes;
+
+	private final String[] axisNames;
+
+	private final String[] units;
+
+	private final double[] scales;
+
+	public ResolutionLevel(
+			final String datasetPath, final int index, final DatasetAttributes attributes, final Axis[] axes, final String[] axisNames,
+			final String[] units, final double[] scales )
+	{
+		this.datasetPath = datasetPath;
+		this.index = index;
+		this.attributes = attributes;
+		this.axes = axes;
+		this.axisNames = axisNames;
+		this.units = units;
+		this.scales = scales;
+	}
+
+	public String getDatasetPath()
+	{
+		return datasetPath;
+	}
+
+	public int getIndex()
+	{
+		return index;
+	}
+
+	public DatasetAttributes getAttributes()
+	{
+		return attributes;
+	}
+
+	public Axis[] getAxes()
+	{
+		return axes;
+	}
+
+	public String[] getAxisNames()
+	{
+		return axisNames;
+	}
+
+	public String[] getUnits()
+	{
+		return units;
+	}
+
+	public double[] getScales()
+	{
+		return scales;
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/AbstractMetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/AbstractMetadataAdapter.java
@@ -1,0 +1,77 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.NgffSingleScaleAxesMetadata;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+import sc.fiji.ome.zarr.pyramid.metadata.Omero;
+import sc.fiji.ome.zarr.pyramid.metadata.ResolutionLevel;
+
+abstract class AbstractMetadataAdapter implements MetadataAdapter
+{
+	protected final N5Reader reader;
+
+	protected final N5TreeNode node;
+
+	protected AbstractMetadataAdapter( final N5Reader reader, final N5TreeNode node )
+	{
+		this.reader = reader;
+		this.node = node;
+	}
+
+	protected Multiscale buildMultiscale( final String name, final NgffSingleScaleAxesMetadata[] children )
+	{
+		final List< ResolutionLevel > levels = new ArrayList<>();
+		int index = 0;
+		for ( NgffSingleScaleAxesMetadata single : children )
+		{
+			levels.add( new ResolutionLevel( single.getPath(), index++, single.getAttributes(), single.getAxes(), null, null,
+					single.getScale() ) );
+		}
+		return new Multiscale( name, levels, children[ 0 ].getAttributes().getDataType() );
+	}
+
+	@Override
+	public Omero initOmeroMetadata()
+	{
+		final JsonElement base = reader.getAttribute( node.getPath(), getOmeroKey(), JsonElement.class );
+		return new Gson().fromJson( base, Omero.class );
+	}
+
+	protected abstract String getOmeroKey();
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapter.java
@@ -1,0 +1,48 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+import sc.fiji.ome.zarr.pyramid.metadata.Omero;
+
+/**
+ * Version-specific bridge from a parsed {@link N5Metadata} to the
+ * library-internal {@link Multiscale} and {@link Omero} representations.
+ * <p>
+ * Use {@link MetadataAdapterFactory#getAdapter} to obtain the right
+ * implementation for a given metadata instance.
+ */
+public interface MetadataAdapter
+{
+	Multiscale initMultiscale( final N5Metadata metadata, final int multiscaleIndex );
+
+	Omero initOmeroMetadata();
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactory.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactory.java
@@ -34,7 +34,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata;
 
-import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 
 /**
  * Picks the appropriate {@link MetadataAdapter} for a given parsed

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactory.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactory.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata;
+
+import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+
+/**
+ * Picks the appropriate {@link MetadataAdapter} for a given parsed
+ * OME-NGFF {@link N5Metadata} (v03, v04, or v05).
+ */
+public class MetadataAdapterFactory
+{
+	private MetadataAdapterFactory()
+	{}
+
+	public static MetadataAdapter getAdapter( final N5Metadata metadata, final N5Reader reader, final N5TreeNode node )
+	{
+		if ( metadata instanceof OmeNgffV05Metadata )
+			return new V05MetadataAdapter( reader, node );
+		if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata )
+			return new V04MetadataAdapter( reader, node );
+		if ( metadata instanceof OmeNgffMetadata )
+			return new V03MetadataAdapter( reader, node );
+		throw new NotAMultiscaleImageException(
+				"Unsupported multiscale metadata type: " + metadata.getClass() );
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V03MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V03MetadataAdapter.java
@@ -39,7 +39,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMultiScaleMetadata;
 
 import net.imglib2.util.Cast;
-import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
 import sc.fiji.ome.zarr.pyramid.metadata.ResolutionLevel;
 

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V03MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V03MetadataAdapter.java
@@ -1,0 +1,75 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5SingleScaleMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMultiScaleMetadata;
+
+import net.imglib2.util.Cast;
+import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+import sc.fiji.ome.zarr.pyramid.metadata.ResolutionLevel;
+
+class V03MetadataAdapter extends AbstractMetadataAdapter
+{
+	V03MetadataAdapter( final N5Reader reader, final N5TreeNode node )
+	{
+		super( reader, node );
+	}
+
+	@Override
+	public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
+	{
+		OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
+		OmeNgffMultiScaleMetadata multiscales = omeNgffMetadata.getMultiscales()[ multiscaleIndex ];
+		if ( multiscales.getChildrenMetadata() == null || multiscales.getChildrenMetadata().length == 0 )
+			throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children metadata." );
+		final List< ResolutionLevel > levels = new ArrayList<>();
+		int index = 0;
+		for ( N5SingleScaleMetadata single : multiscales.getChildrenMetadata() )
+		{
+			levels.add( new ResolutionLevel( single.getPath(), index++, single.getAttributes(), null, multiscales.axes, multiscales.units(),
+					single.getPixelResolution() ) );
+		}
+		return new Multiscale( multiscales.name, levels, multiscales.getChildrenMetadata()[ 0 ].getAttributes().getDataType() );
+	}
+
+	@Override
+	protected String getOmeroKey()
+	{
+		return "omero";
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V04MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V04MetadataAdapter.java
@@ -35,7 +35,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
 
 import net.imglib2.util.Cast;
-import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
 
 class V04MetadataAdapter extends AbstractMetadataAdapter

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V04MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V04MetadataAdapter.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
+
+import net.imglib2.util.Cast;
+import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+
+class V04MetadataAdapter extends AbstractMetadataAdapter
+{
+	V04MetadataAdapter( final N5Reader reader, final N5TreeNode node )
+	{
+		super( reader, node );
+	}
+
+	@Override
+	public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
+	{
+		OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
+		OmeNgffMultiScaleMetadata multiscales = omeNgffMetadata.multiscales[ multiscaleIndex ];
+		if ( multiscales.getChildrenMetadata().length == 0 || multiscales.getChildrenMetadata()[ 0 ] == null )
+			throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children attributes." );
+		return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
+	}
+
+	@Override
+	protected String getOmeroKey()
+	{
+		return "omero";
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V05MetadataAdapter.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/V05MetadataAdapter.java
@@ -1,0 +1,61 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata;
+
+import net.imglib2.util.Cast;
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+
+class V05MetadataAdapter extends AbstractMetadataAdapter
+{
+	V05MetadataAdapter( final N5Reader reader, final N5TreeNode node )
+	{
+		super( reader, node );
+	}
+
+	@Override
+	public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
+	{
+		OmeNgffV05Metadata omeNgffMetadata = Cast.unchecked( n5Metadata );
+		// NB: v05 reuses v04 multi scale metadata
+		OmeNgffMultiScaleMetadata multiscales = omeNgffMetadata.multiscales[ multiscaleIndex ];
+		return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
+	}
+
+	@Override
+	protected String getOmeroKey()
+	{
+		return "ome/omero";
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/util/ZarrOpenActions.java
@@ -53,10 +53,10 @@ import net.imglib2.util.Cast;
 import bdv.util.BdvFunctions;
 import ij.IJ;
 import sc.fiji.ome.zarr.pyramid.DefaultPyramidal5DImageData;
-import sc.fiji.ome.zarr.pyramid.NoMatchingResolutionException;
-import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
-import sc.fiji.ome.zarr.pyramid.NotASingleScaleImageException;
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
+import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotASingleScaleImageException;
 import sc.fiji.ome.zarr.settings.ZarrDragAndDropOpenSettings;
 import sc.fiji.ome.zarr.settings.ZarrOpenBehavior;
 

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageDataTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageDataTest.java
@@ -55,6 +55,7 @@ import bdv.tools.brightness.ConverterSetup;
 import bdv.util.BdvHandle;
 import bdv.viewer.Source;
 import mpicbg.spim.data.sequence.VoxelDimensions;
+import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.util.BdvUtils;
 import sc.fiji.ome.zarr.util.ZarrTestUtils;
 

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/MultiscaleImage.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/MultiscaleImage.java
@@ -60,6 +60,8 @@ import bdv.util.volatiles.VolatileViews;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
+
 public class MultiscaleImage<
 		T extends NativeType< T > & RealType< T >,
 		V extends Volatile< T > & NativeType< V > & RealType< V > >

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactoryTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactoryTest.java
@@ -50,7 +50,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.N5MetadataParser;
 import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata;
 import org.junit.jupiter.api.Test;
 
-import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
 import sc.fiji.ome.zarr.util.ZarrTestUtils;
 

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactoryTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/metadata/adapter/MetadataAdapterFactoryTest.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.universe.N5DatasetDiscoverer;
+import org.janelia.saalfeldlab.n5.universe.N5Factory;
+import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.N5MetadataParser;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata;
+import org.junit.jupiter.api.Test;
+
+import sc.fiji.ome.zarr.pyramid.NotAMultiscaleImageException;
+import sc.fiji.ome.zarr.pyramid.metadata.Multiscale;
+import sc.fiji.ome.zarr.util.ZarrTestUtils;
+
+class MetadataAdapterFactoryTest
+{
+	private static final String V04_FIXTURE = "sc/fiji/ome/zarr/util/2d_testing/2d_dataset_v4.ome.zarr";
+
+	private static final String V05_FIXTURE = "sc/fiji/ome/zarr/util/2d_testing/2d_dataset_v5.ome.zarr";
+
+	@Test
+	void v04MetadataYieldsV04Adapter() throws URISyntaxException
+	{
+		Loaded loaded = load( V04_FIXTURE );
+		MetadataAdapter adapter = MetadataAdapterFactory.getAdapter( loaded.metadata, loaded.reader, loaded.node );
+		assertInstanceOf( V04MetadataAdapter.class, adapter );
+	}
+
+	@Test
+	void v05MetadataYieldsV05Adapter() throws URISyntaxException
+	{
+		Loaded loaded = load( V05_FIXTURE );
+		MetadataAdapter adapter = MetadataAdapterFactory.getAdapter( loaded.metadata, loaded.reader, loaded.node );
+		assertInstanceOf( V05MetadataAdapter.class, adapter );
+	}
+
+	@Test
+	void v03MetadataYieldsV03Adapter()
+	{
+		// No v03 fixture exists; a mock is enough to exercise the instanceof dispatch
+		org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata v03 = mock( OmeNgffMetadata.class );
+		MetadataAdapter adapter = MetadataAdapterFactory.getAdapter( v03, mock( N5Reader.class ), new N5TreeNode( "" ) );
+		assertInstanceOf( V03MetadataAdapter.class, adapter );
+	}
+
+	@Test
+	@SuppressWarnings( "resource" )
+	void unknownMetadataThrows()
+	{
+		N5Metadata unknown = mock( N5Metadata.class );
+		N5Reader reader = mock( N5Reader.class );
+		N5TreeNode node = new N5TreeNode( "" );
+		assertThrows( NotAMultiscaleImageException.class,
+				() -> MetadataAdapterFactory.getAdapter( unknown, reader, node ) );
+	}
+
+	@Test
+	void initMultiscaleProducesExpectedPyramid() throws URISyntaxException
+	{
+		Loaded loaded = load( V05_FIXTURE );
+		MetadataAdapter adapter = MetadataAdapterFactory.getAdapter( loaded.metadata, loaded.reader, loaded.node );
+		Multiscale multiscale = adapter.initMultiscale( loaded.metadata, 0 );
+		assertNotNull( multiscale );
+		assertEquals( 2, multiscale.numResolutionLevels() );
+		assertEquals( DataType.UINT8, multiscale.getDataType() );
+		assertEquals( 0, multiscale.getLevels().get( 0 ).getIndex() );
+		assertEquals( 1, multiscale.getLevels().get( 1 ).getIndex() );
+	}
+
+	private static Loaded load( final String resource ) throws URISyntaxException
+	{
+		Path path = ZarrTestUtils.resourcePath( resource );
+		N5Reader reader = new N5Factory().openReader( path.toUri().toString() );
+		N5TreeNode node = new N5TreeNode( "" );
+		List< N5MetadataParser< ? > > parsers = Arrays.asList(
+				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadataParser(),
+				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadataParser(),
+				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05MetadataParser() );
+		N5DatasetDiscoverer.parseMetadataShallow( reader, node, parsers, new ArrayList<>( parsers ) );
+		N5Metadata metadata = node.getMetadata();
+		assertNotNull( metadata, "Parser produced no metadata for " + resource );
+		return new Loaded( reader, node, metadata );
+	}
+
+	private static final class Loaded
+	{
+		final N5Reader reader;
+
+		final N5TreeNode node;
+
+		final N5Metadata metadata;
+
+		Loaded( final N5Reader reader, final N5TreeNode node, final N5Metadata metadata )
+		{
+			this.reader = reader;
+			this.node = node;
+			this.metadata = metadata;
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors the `DefaultPyramidal5DImageData` class by moving the `Multiscale`, `ResolutionLevel` and `Adapter` classes into a new `metadata` package, updating code to use accessor methods, and relocating exception classes to a dedicated `exceptions` package.

### MetadataAdapter  Refactoring

* Moved the `Adapter` classes from inner classes in `DefaultPyramidal5DImageData` to new standalone files in the `sc.fiji.ome.zarr.pyramid.metadata.adapter` package.

### Metadata  Refactoring

* Moved the `Multiscale`, `ResolutionLevel` classes from inner classes in `DefaultPyramidal5DImageData` to new standalone files in the `sc.fiji.ome.zarr.pyramid.metadata` package.

### Exceptions

* Moved exception classes (`NoMatchingResolutionException`, `NotAMultiscaleImageException`, `NotASingleScaleImageException`) to a new `sc.fiji.ome.zarr.pyramid.exceptions` package for clearer separation.