### PR TITLE
Add image plus API calls

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/DefaultPyramidal5DImageData.java
@@ -59,6 +59,7 @@ import org.janelia.saalfeldlab.n5.universe.metadata.N5SingleScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.SpatialMetadataGroup;
 import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
 import org.scijava.Context;
+import org.scijava.convert.ConvertService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +83,7 @@ import bdv.util.RandomAccessibleIntervalMipmapSource4D;
 import bdv.util.volatiles.VolatileTypeMatcher;
 import bdv.util.volatiles.VolatileViews;
 import bdv.viewer.SourceAndConverter;
+import ij.ImagePlus;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
@@ -795,5 +797,11 @@ public class DefaultPyramidal5DImageData<
 	public Omero getOmeroProperties()
 	{
 		return omero;
+	}
+
+	@Override
+	public ImagePlus asImagePlus()
+	{
+		return context.service( ConvertService.class ).convert( asDataset(), ImagePlus.class );
 	}
 }

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -35,6 +35,7 @@ import net.imglib2.type.numeric.RealType;
 import java.util.List;
 
 import bdv.viewer.SourceAndConverter;
+import ij.ImagePlus;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
@@ -85,4 +86,6 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	{
 		return null;
 	}
+
+	ImagePlus asImagePlus();
 }

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/PyramidalDataset.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/PyramidalDataset.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,12 +29,15 @@
 package sc.fiji.ome.zarr.pyramid;
 
 import net.imagej.DefaultDataset;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
 import java.util.List;
 
 import bdv.viewer.SourceAndConverter;
+import ij.ImagePlus;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
@@ -90,5 +93,22 @@ public class PyramidalDataset< T extends NativeType< T > & RealType< T > > exten
 	public String getPyramidName()
 	{
 		return data.getName();
+	}
+
+	/**
+	 * Converts this {@code PyramidalDataset} into an {@code ImagePlus} object for a given resolution level,
+	 * channel, and timepoint.
+	 *
+	 * @param resolutionLevel The resolution level to use for extracting the image data.
+	 * @param channel The channel index to extract from the dataset.
+	 * @param timepoint The timepoint index to extract from the dataset.
+	 * @return An {@code ImagePlus} object representing the extracted image data.
+	 */
+	public ImagePlus getImagePlus( final int resolutionLevel, final int channel, final int timepoint )
+	{
+		final SourceAndConverter< T > sourceAndConverter = this.asSources().get( channel );
+		final RandomAccessibleInterval< T > randomAccessibleInterval =
+				sourceAndConverter.getSpimSource().getSource( timepoint, resolutionLevel );
+		return ImageJFunctions.wrap( randomAccessibleInterval, sourceAndConverter.getSpimSource().getName() );
 	}
 }

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
@@ -53,15 +53,14 @@ import sc.fiji.ome.zarr.util.ZarrTestUtils;
 class Pyramidal5DImageDataAsImagePlusTest
 {
 	@Test
-	void testOpenAsImagePlus() throws URISyntaxException
+	void testOpenAsImagePlusConvertService() throws URISyntaxException
 	{
 		final Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr" );
 
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > image = new DefaultPyramidal5DImageData<>( context, path.toString() );
-			final Dataset dataset = image.asDataset();
-			final ImagePlus imagePlus = context.service( ConvertService.class ).convert( dataset, ImagePlus.class );
+			final Pyramidal5DImageData< ? > pyramidal5DImageData = new DefaultPyramidal5DImageData<>( context, path.toString() );
+			final ImagePlus imagePlus = pyramidal5DImageData.asImagePlus();
 
 			assertNotNull( imagePlus );
 			// order of dimensions for imagePlus: width, height, channels, slices, frames

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
@@ -69,4 +69,32 @@ class Pyramidal5DImageDataAsImagePlusTest
 			assertEquals( ZarrTestUtils.IMAGE_NAME, imagePlus.getTitle() );
 		}
 	}
+
+	@Test
+	void testOpenAsImagePlusSourceAndConverter() throws URISyntaxException
+	{
+		final Path path = ZarrTestUtils.resourcePath( "sc/fiji/ome/zarr/util/5d_testing/5d_dataset_v5.ome.zarr" );
+
+		try (Context context = new Context())
+		{
+			final PyramidalDataset< ? > pyramidalDataset =
+					new DefaultPyramidal5DImageData<>( context, path.toString() ).asPyramidalDataset();
+			int resolutionLevel = 0;
+			int channel = 0; // NB: 3 channels, channel 0 has the name: lynEGFP
+			int timepoint = 0;
+			ImagePlus imagePlus = pyramidalDataset.getImagePlus( resolutionLevel, channel, timepoint );
+
+			assertNotNull( imagePlus );
+			// order of dimensions for imagePlus: width, height, slices. Channel and timepoint are 1.
+			assertArrayEquals( new int[] { 64, 64, 16, 1, 1 }, imagePlus.getDimensions() );
+			assertEquals( "lynEGFP", imagePlus.getTitle() );
+
+			resolutionLevel = 1;
+			imagePlus = pyramidalDataset.getImagePlus( resolutionLevel, channel, timepoint );
+			assertNotNull( imagePlus );
+			// order of dimensions for imagePlus: width, height, slices. Channel and timepoint are 1.
+			assertArrayEquals( new int[] { 32, 32, 8, 1, 1 }, imagePlus.getDimensions() );
+			assertEquals( "lynEGFP", imagePlus.getTitle() );
+		}
+	}
 }


### PR DESCRIPTION
This PR adds API support for converting pyramidal image data to `ImagePlus` objects.

**New and Improved Conversion Methods:**

* Added an `asImagePlus()` method to the `Pyramidal5DImageData` interface and implemented it in `DefaultPyramidal5DImageData`, enabling direct conversion of a pyramidal image to an `ImagePlus` using the `ConvertService`.
* Introduced a `getImagePlus(int resolutionLevel, int channel, int timepoint)` method to `PyramidalDataset`, allowing extraction of an `ImagePlus` for a specific resolution, channel, and timepoint using `SourceAndConverter` and `ImageJFunctions`.

**Test Enhancements:**

* Expanded tests in `Pyramidal5DImageDataAsImagePlusTest` to cover both the new `asImagePlus()` and `getImagePlus()` methods.