### PR TITLE
Remove imgPlus from PyramidContents; make backend package net.imagej-free

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -282,7 +282,7 @@ public class ZarrOpenActions
 		{
 			@SuppressWarnings( { "rawtypes", "unchecked" } )
 			final Pyramidal5DImageDataImpl< ?, ? > zarrJavaData =
-					new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( inputUri, preferredWidth ) );
+					new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( inputUri ) );
 			data = zarrJavaData;
 			break;
 		}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
@@ -165,6 +165,6 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithZarrJava(
 			final Context context, final URI uri, final Integer preferredWidth )
 	{
-		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri, preferredWidth ) );
+		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri, preferredWidth ), preferredWidth );
 	}
 }

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
@@ -165,6 +165,6 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithZarrJava(
 			final Context context, final URI uri, final Integer preferredWidth )
 	{
-		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri, preferredWidth ), preferredWidth );
+		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri ), preferredWidth );
 	}
 }

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
@@ -153,7 +153,7 @@ public class Pyramidal5DImageDataImpl<
 	 */
 	public Pyramidal5DImageDataImpl( final Context context, final URI inputUri, final Integer preferredMaxWidth )
 	{
-		this( context, new N5PyramidBackend<>( inputUri, preferredMaxWidth ), preferredMaxWidth );
+		this( context, new N5PyramidBackend<>( inputUri ), preferredMaxWidth );
 	}
 
 	/**

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -43,6 +43,7 @@ import net.imagej.axis.AxisType;
 import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.EuclideanSpace;
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.Volatile;
 import net.imglib2.converter.Converter;
 import net.imglib2.realtransform.AffineTransform3D;
@@ -152,13 +153,29 @@ public class Pyramidal5DImageDataImpl<
 	 */
 	public Pyramidal5DImageDataImpl( final Context context, final URI inputUri, final Integer preferredMaxWidth )
 	{
-		this( context, new N5PyramidBackend<>( inputUri, preferredMaxWidth ) );
+		this( context, new N5PyramidBackend<>( inputUri, preferredMaxWidth ), preferredMaxWidth );
 	}
 
 	/**
-	 * Open an OME-Zarr image using the supplied {@link PyramidBackend}.
+	 * Open an OME-Zarr image using the supplied {@link PyramidBackend}, using
+	 * the highest available resolution for the ImageJ dataset.
 	 */
 	public Pyramidal5DImageDataImpl( final Context context, final PyramidBackend< T, V > backend )
+	{
+		this( context, backend, null );
+	}
+
+	/**
+	 * Open an OME-Zarr image using the supplied {@link PyramidBackend},
+	 * selecting for the ImageJ dataset the coarsest resolution level whose
+	 * x-width does not exceed {@code preferredMaxWidth}. If
+	 * {@code preferredMaxWidth} is {@code null}, the highest resolution is
+	 * used.
+	 *
+	 * @throws NoMatchingResolutionException if {@code preferredMaxWidth} is
+	 *   smaller than the width of the smallest resolution level
+	 */
+	public Pyramidal5DImageDataImpl( final Context context, final PyramidBackend< T, V > backend, final Integer preferredMaxWidth )
 	{
 		final PyramidContents< T, V > contents = backend.load();
 		this.context = context;
@@ -173,7 +190,8 @@ public class Pyramidal5DImageDataImpl<
 		this.transforms = contents.transforms;
 		this.omero = contents.omero;
 
-		final ImgPlus< T > imgPlus = new ImgPlus<>( contents.cachedCellImgs[ contents.selectedResolutionLevelIndex ], name );
+		final int resolutionLevel = selectResolutionLevel( contents.cachedCellImgs, preferredMaxWidth );
+		final ImgPlus< T > imgPlus = new ImgPlus<>( contents.cachedCellImgs[ resolutionLevel ], name );
 		for ( int i = 0; i < contents.axes.length; i++ )
 		{
 			final AxisType axisType = AXIS_TYPE_MAP.getOrDefault( contents.axes[ i ].name, Axes.unknown() );
@@ -184,6 +202,27 @@ public class Pyramidal5DImageDataImpl<
 		this.ijDataset.setRGBMerged( false );
 
 		this.sourceAndConverters = initSourceAndConverters( contents );
+	}
+
+	/**
+	 * Returns the index of the coarsest resolution level whose x-width (index 0
+	 * in imglib2 F-order) is ≤ {@code preferredMaxWidth}, or 0 when
+	 * {@code preferredMaxWidth} is {@code null}.
+	 */
+	private static < T extends NativeType< T > & RealType< T > > int selectResolutionLevel(
+			final CachedCellImg< T, ? >[] cachedCellImgs, final Integer preferredMaxWidth )
+	{
+		if ( preferredMaxWidth == null )
+			return 0;
+		int smallestWidth = Integer.MAX_VALUE;
+		for ( int level = 0; level < cachedCellImgs.length; level++ )
+		{
+			final int width = ( int ) cachedCellImgs[ level ].dimension( 0 );
+			if ( width <= preferredMaxWidth )
+				return level;
+			smallestWidth = Math.min( smallestWidth, width );
+		}
+		throw new NoMatchingResolutionException( preferredMaxWidth, smallestWidth );
 	}
 
 	private List< SourceAndConverter< T > > initSourceAndConverters( final PyramidContents< T, V > contents )

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataImpl.java
@@ -30,10 +30,17 @@ package sc.fiji.ome.zarr.pyramid;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import net.imagej.Dataset;
 import net.imagej.DefaultDataset;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.EuclideanSpace;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
@@ -57,6 +64,7 @@ import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidBackend;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidContents;
 import sc.fiji.ome.zarr.pyramid.backend.n5.N5PyramidBackend;
+import sc.fiji.ome.zarr.pyramid.metadata.AxisCalibration;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
 /**
@@ -81,6 +89,19 @@ public class Pyramidal5DImageDataImpl<
 		V extends Volatile< T > & NativeType< V > & RealType< V > >
 		implements EuclideanSpace, Pyramidal5DImageData< T >
 {
+	private static final Map< String, AxisType > AXIS_TYPE_MAP;
+
+	static
+	{
+		final Map< String, AxisType > map = new HashMap<>();
+		map.put( AxisCalibration.X, Axes.X );
+		map.put( AxisCalibration.Y, Axes.Y );
+		map.put( AxisCalibration.Z, Axes.Z );
+		map.put( AxisCalibration.C, Axes.CHANNEL );
+		map.put( AxisCalibration.T, Axes.TIME );
+		AXIS_TYPE_MAP = Collections.unmodifiableMap( map );
+	}
+
 	private final Context context;
 
 	private final String name;
@@ -152,7 +173,13 @@ public class Pyramidal5DImageDataImpl<
 		this.transforms = contents.transforms;
 		this.omero = contents.omero;
 
-		this.ijDataset = new DefaultDataset( context, contents.imgPlus );
+		final ImgPlus< T > imgPlus = new ImgPlus<>( contents.cachedCellImgs[ contents.selectedResolutionLevelIndex ], name );
+		for ( int i = 0; i < contents.axes.length; i++ )
+		{
+			final AxisType axisType = AXIS_TYPE_MAP.getOrDefault( contents.axes[ i ].name, Axes.unknown() );
+			imgPlus.setAxis( new DefaultLinearAxis( axisType, contents.axes[ i ].unit, contents.axes[ i ].scale ), i );
+		}
+		this.ijDataset = new DefaultDataset( context, imgPlus );
 		this.ijDataset.setName( name );
 		this.ijDataset.setRGBMerged( false );
 

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/PyramidContents.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/PyramidContents.java
@@ -28,7 +28,6 @@
  */
 package sc.fiji.ome.zarr.pyramid.backend;
 
-import net.imagej.ImgPlus;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
 import net.imglib2.cache.img.CachedCellImg;
@@ -37,6 +36,7 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
 
 import mpicbg.spim.data.sequence.VoxelDimensions;
+import sc.fiji.ome.zarr.pyramid.metadata.AxisCalibration;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
 /**
@@ -80,7 +80,7 @@ public final class PyramidContents<
 
 	public final RandomAccessibleInterval< V >[] volatileImgs;
 
-	public final ImgPlus< T > imgPlus;
+	public final AxisCalibration[] axes;
 
 	/** imglib2-order index of the channel axis, or -1 if absent. */
 	public final int channelAxisIndex;
@@ -111,7 +111,7 @@ public final class PyramidContents<
 		this.transforms = b.transforms;
 		this.cachedCellImgs = b.cachedCellImgs;
 		this.volatileImgs = b.volatileImgs;
-		this.imgPlus = b.imgPlus;
+		this.axes = b.axes;
 		this.channelAxisIndex = b.channelAxisIndex;
 		this.zAxisPresent = b.zAxisPresent;
 		this.timeAxisPresent = b.timeAxisPresent;
@@ -154,7 +154,7 @@ public final class PyramidContents<
 
 		private RandomAccessibleInterval< V >[] volatileImgs;
 
-		private ImgPlus< T > imgPlus;
+		private AxisCalibration[] axes;
 
 		private int channelAxisIndex = -1;
 
@@ -238,9 +238,9 @@ public final class PyramidContents<
 			return this;
 		}
 
-		public Builder< T, V > imgPlus( final ImgPlus< T > i )
+		public Builder< T, V > axes( final AxisCalibration[] a )
 		{
-			this.imgPlus = i;
+			this.axes = a;
 			return this;
 		}
 

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/PyramidContents.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/PyramidContents.java
@@ -66,8 +66,6 @@ public final class PyramidContents<
 
 	public final int numDimensions;
 
-	public final int selectedResolutionLevelIndex;
-
 	public final T type;
 
 	public final V volatileType;
@@ -104,7 +102,6 @@ public final class PyramidContents<
 		this.numChannels = b.numChannels;
 		this.numTimepoints = b.numTimepoints;
 		this.numDimensions = b.numDimensions;
-		this.selectedResolutionLevelIndex = b.selectedResolutionLevelIndex;
 		this.type = b.type;
 		this.volatileType = b.volatileType;
 		this.voxelDimensions = b.voxelDimensions;
@@ -139,8 +136,6 @@ public final class PyramidContents<
 		private int numTimepoints;
 
 		private int numDimensions;
-
-		private int selectedResolutionLevelIndex;
 
 		private T type;
 
@@ -193,12 +188,6 @@ public final class PyramidContents<
 		public Builder< T, V > numDimensions( final int n )
 		{
 			this.numDimensions = n;
-			return this;
-		}
-
-		public Builder< T, V > selectedResolutionLevelIndex( final int i )
-		{
-			this.selectedResolutionLevelIndex = i;
 			return this;
 		}
 

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -76,7 +76,7 @@ import sc.fiji.ome.zarr.util.Affine3DUtils;
 
 /**
  * {@link PyramidBackend} that reads OME-Zarr images with the N5 universe
- * library. Supports OME-NGFF v0.3, v0.4 and v0.5 (N5 reads Zarr v2 and the
+ * library. Supports OME-Zarr v0.3, v0.4 and v0.5 (N5 reads Zarr v2 and the
  * Zarr v3 variant used by v0.5).
  *
  * @param <T> pixel type
@@ -342,7 +342,7 @@ public class N5PyramidBackend<
 	}
 
 	// ---------------------------------------------------------------------
-	// Metadata adapter strategy (per OME-NGFF version)
+	// Metadata adapter strategy (per OME-Zarr version)
 	// ---------------------------------------------------------------------
 
 	private interface MetadataAdapter

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
@@ -66,7 +66,6 @@ import bdv.util.volatiles.VolatileViews;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import sc.fiji.ome.zarr.pyramid.exceptions.MultiImageDatasetException;
-import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidBackend;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidContents;
@@ -91,17 +90,9 @@ public class N5PyramidBackend<
 
 	private final URI inputUri;
 
-	private final Integer preferredMaxWidth;
-
 	public N5PyramidBackend( final URI inputUri )
 	{
-		this( inputUri, null );
-	}
-
-	public N5PyramidBackend( final URI inputUri, final Integer preferredMaxWidth )
-	{
 		this.inputUri = inputUri;
-		this.preferredMaxWidth = preferredMaxWidth;
 	}
 
 	@Override
@@ -114,7 +105,7 @@ public class N5PyramidBackend<
 		final int multiscaleIndex = 0;
 		final Multiscale multiscale = adapter.initMultiscale( metadata, multiscaleIndex );
 		final Omero omero = adapter.initOmeroMetadata();
-		final ResolutionLevel selectedLevel = selectResolutionLevel( preferredMaxWidth, multiscale );
+		final ResolutionLevel level0 = multiscale.getLevels().get( 0 );
 
 		final SpatialMetadataGroup< ? > spatialMetadata = Cast.unchecked( metadata );
 		final AffineTransform3D[] transforms = spatialMetadata.spatialTransforms3d();
@@ -123,9 +114,9 @@ public class N5PyramidBackend<
 		final V volatileType = Cast.unchecked( VolatileTypeMatcher.getVolatileTypeForType( type ) );
 		final String name = multiscale.getName();
 		final int numResolutionLevels = multiscale.numResolutionLevels();
-		final int numDimensions = selectedLevel.attributes.getDimensions().length;
-		final int numTimepoints = getAxisSize( selectedLevel, AxisCalibration.T );
-		final int numChannels = getAxisSize( selectedLevel, AxisCalibration.C );
+		final int numDimensions = level0.attributes.getDimensions().length;
+		final int numTimepoints = getAxisSize( level0, AxisCalibration.T );
+		final int numChannels = getAxisSize( level0, AxisCalibration.C );
 
 		final SharedQueue sharedQueue = new SharedQueue( Math.max( 1, Runtime.getRuntime().availableProcessors() / 2 ) );
 		final CachedCellImg< T, ? >[] cachedCellImgs = Cast.unchecked( new CachedCellImg[ numResolutionLevels ] );
@@ -136,11 +127,11 @@ public class N5PyramidBackend<
 			volatileImgs[ level.index ] = VolatileViews.wrapAsVolatile( cachedCellImgs[ level.index ], sharedQueue );
 		}
 
-		final AxisCalibration[] axes = createAxisCalibrations( selectedLevel );
+		final AxisCalibration[] axes = createAxisCalibrations( level0 );
 
-		final int channelAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.C );
-		final int zAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.Z );
-		final int timeAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.T );
+		final int channelAxisIndex = findAxisIndex( level0, AxisCalibration.C );
+		final int zAxisIndex = findAxisIndex( level0, AxisCalibration.Z );
+		final int timeAxisIndex = findAxisIndex( level0, AxisCalibration.T );
 
 		final String[] channelLabels = Omero.buildChannelLabels( name, omero, numChannels );
 
@@ -205,21 +196,6 @@ public class N5PyramidBackend<
 		final double scaleY = transform.get( 1, 1 );
 		final double scaleZ = transform.get( 2, 2 );
 		return new FinalVoxelDimensions( unit, scaleX, scaleY, scaleZ );
-	}
-
-	private ResolutionLevel selectResolutionLevel( final Integer preferredMaxWidth, final Multiscale multiscale )
-	{
-		ResolutionLevel resolutionLevel = multiscale.getLevels().get( 0 );
-		if ( preferredMaxWidth == null )
-			return resolutionLevel;
-		int width = 0;
-		for ( final ResolutionLevel level : multiscale.getLevels() )
-		{
-			width = getAxisSize( level, AxisCalibration.X );
-			if ( width <= preferredMaxWidth )
-				return level;
-		}
-		throw new NoMatchingResolutionException( preferredMaxWidth, width );
 	}
 
 	// ---------------------------------------------------------------------

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
@@ -150,7 +150,6 @@ public class N5PyramidBackend<
 				.numChannels( numChannels )
 				.numTimepoints( numTimepoints )
 				.numDimensions( numDimensions )
-				.selectedResolutionLevelIndex( selectedLevel.index )
 				.type( type )
 				.volatileType( volatileType )
 				.voxelDimensions( voxelDimensions )

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
@@ -32,15 +32,8 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import net.imagej.ImgPlus;
-import net.imagej.axis.Axes;
-import net.imagej.axis.AxisType;
-import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
 import net.imglib2.cache.img.CachedCellImg;
@@ -77,6 +70,7 @@ import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidBackend;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidContents;
+import sc.fiji.ome.zarr.pyramid.metadata.AxisCalibration;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 import sc.fiji.ome.zarr.util.Affine3DUtils;
 
@@ -94,19 +88,6 @@ public class N5PyramidBackend<
 		implements PyramidBackend< T, V >
 {
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
-
-	private static final Map< String, AxisType > AXIS_MAPPING;
-
-	static
-	{
-		final Map< String, AxisType > map = new HashMap<>();
-		map.put( "x", Axes.X );
-		map.put( "y", Axes.Y );
-		map.put( "z", Axes.Z );
-		map.put( "c", Axes.CHANNEL );
-		map.put( "t", Axes.TIME );
-		AXIS_MAPPING = Collections.unmodifiableMap( map );
-	}
 
 	private final URI inputUri;
 
@@ -143,8 +124,8 @@ public class N5PyramidBackend<
 		final String name = multiscale.getName();
 		final int numResolutionLevels = multiscale.numResolutionLevels();
 		final int numDimensions = selectedLevel.attributes.getDimensions().length;
-		final int numTimepoints = getAxisSize( selectedLevel, Axes.TIME );
-		final int numChannels = getAxisSize( selectedLevel, Axes.CHANNEL );
+		final int numTimepoints = getAxisSize( selectedLevel, AxisCalibration.T );
+		final int numChannels = getAxisSize( selectedLevel, AxisCalibration.C );
 
 		final SharedQueue sharedQueue = new SharedQueue( Math.max( 1, Runtime.getRuntime().availableProcessors() / 2 ) );
 		final CachedCellImg< T, ? >[] cachedCellImgs = Cast.unchecked( new CachedCellImg[ numResolutionLevels ] );
@@ -155,12 +136,11 @@ public class N5PyramidBackend<
 			volatileImgs[ level.index ] = VolatileViews.wrapAsVolatile( cachedCellImgs[ level.index ], sharedQueue );
 		}
 
-		final ImgPlus< T > imgPlus = new ImgPlus<>( cachedCellImgs[ selectedLevel.index ], name );
-		configureImgPlusAxes( imgPlus, selectedLevel );
+		final AxisCalibration[] axes = createAxisCalibrations( selectedLevel );
 
-		final int channelAxisIndex = findAxisIndex( selectedLevel, Axes.CHANNEL );
-		final int zAxisIndex = findAxisIndex( selectedLevel, Axes.Z );
-		final int timeAxisIndex = findAxisIndex( selectedLevel, Axes.TIME );
+		final int channelAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.C );
+		final int zAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.Z );
+		final int timeAxisIndex = findAxisIndex( selectedLevel, AxisCalibration.T );
 
 		final String[] channelLabels = Omero.buildChannelLabels( name, omero, numChannels );
 
@@ -177,7 +157,7 @@ public class N5PyramidBackend<
 				.transforms( transforms )
 				.cachedCellImgs( cachedCellImgs )
 				.volatileImgs( volatileImgs )
-				.imgPlus( imgPlus )
+				.axes( axes )
 				.channelAxisIndex( channelAxisIndex )
 				.zAxisPresent( zAxisIndex > 0 )
 				.timeAxisPresent( timeAxisIndex > 0 )
@@ -236,7 +216,7 @@ public class N5PyramidBackend<
 		int width = 0;
 		for ( final ResolutionLevel level : multiscale.getLevels() )
 		{
-			width = getAxisSize( level, Axes.X );
+			width = getAxisSize( level, AxisCalibration.X );
 			if ( width <= preferredMaxWidth )
 				return level;
 		}
@@ -247,43 +227,46 @@ public class N5PyramidBackend<
 	// Axis configuration
 	// ---------------------------------------------------------------------
 
-	private void configureImgPlusAxes( final ImgPlus< T > img, final ResolutionLevel level )
+	private AxisCalibration[] createAxisCalibrations( final ResolutionLevel level )
 	{
 		if ( level.axes != null )
 		{
+			final AxisCalibration[] result = new AxisCalibration[ level.axes.length ];
 			for ( int i = 0; i < level.axes.length; i++ )
 			{
 				final Axis axis = level.axes[ i ];
-				img.setAxis( new DefaultLinearAxis( AXIS_MAPPING.get( axis.getName() ), axis.getUnit(), level.scales[ i ] ), i );
+				result[ i ] = new AxisCalibration( axis.getName(), axis.getUnit(), level.scales[ i ] );
 			}
+			return result;
 		}
-		else if ( level.axisNames != null )
+		if ( level.axisNames != null )
 		{
+			final AxisCalibration[] result = new AxisCalibration[ level.axisNames.length ];
 			for ( int i = 0; i < level.axisNames.length; i++ )
-			{
-				img.setAxis( new DefaultLinearAxis( AXIS_MAPPING.get( level.axisNames[ i ] ), level.units[ i ], level.scales[ i ] ), i );
-			}
+				result[ i ] = new AxisCalibration( level.axisNames[ i ], level.units[ i ], level.scales[ i ] );
+			return result;
 		}
+		return new AxisCalibration[ 0 ];
 	}
 
-	private int getAxisSize( final ResolutionLevel level, final AxisType axisType )
+	private int getAxisSize( final ResolutionLevel level, final String axisName )
 	{
-		final int axisIndex = findAxisIndex( level, axisType );
+		final int axisIndex = findAxisIndex( level, axisName );
 		return axisIndex >= 0 ? ( int ) level.attributes.getDimensions()[ axisIndex ] : 1;
 	}
 
-	private int findAxisIndex( final ResolutionLevel level, final AxisType axisType )
+	private int findAxisIndex( final ResolutionLevel level, final String axisName )
 	{
 		if ( level.axes != null )
 		{
 			for ( int i = 0; i < level.axes.length; i++ )
-				if ( axisType.equals( AXIS_MAPPING.get( level.axes[ i ].getName() ) ) )
+				if ( axisName.equals( level.axes[ i ].getName() ) )
 					return i;
 		}
 		else if ( level.axisNames != null )
 		{
 			for ( int i = 0; i < level.axisNames.length; i++ )
-				if ( axisType.equals( AXIS_MAPPING.get( level.axisNames[ i ] ) ) )
+				if ( axisName.equals( level.axisNames[ i ] ) )
 					return i;
 		}
 		return -1;

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
@@ -181,7 +181,6 @@ public class ZarrJavaPyramidBackend<
 				.numChannels( numChannels )
 				.numTimepoints( numTimepoints )
 				.numDimensions( numDimensions )
-				.selectedResolutionLevelIndex( selectedResolutionLevelIndex )
 				.type( type )
 				.volatileType( volatileType )
 				.voxelDimensions( voxelDimensions )

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
@@ -84,7 +84,6 @@ import bdv.util.volatiles.VolatileViews;
 import mpicbg.spim.data.sequence.FinalVoxelDimensions;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import sc.fiji.ome.zarr.pyramid.exceptions.MultiImageDatasetException;
-import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.exceptions.PyramidLevelAccessException;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidBackend;
@@ -108,19 +107,11 @@ public class ZarrJavaPyramidBackend<
 
 	private final URI inputUri;
 
-	private final Integer preferredMaxWidth;
-
 	private StoreHandle activeHandle = null;
 
 	public ZarrJavaPyramidBackend( final URI inputUri )
 	{
-		this( inputUri, null );
-	}
-
-	public ZarrJavaPyramidBackend( final URI inputUri, final Integer preferredMaxWidth )
-	{
 		this.inputUri = inputUri;
-		this.preferredMaxWidth = preferredMaxWidth;
 	}
 
 	@Override
@@ -130,16 +121,13 @@ public class ZarrJavaPyramidBackend<
 		final MultiscalesEntry entry = readMultiscalesEntry( multiscaleImage );
 
 		final int numResolutionLevels = countResolutionLevels( multiscaleImage );
-		final int selectedResolutionLevelIndex =
-				selectResolutionLevelIndex( multiscaleImage, entry, numResolutionLevels, preferredMaxWidth );
 
 		final Array level0Array = openLevel( multiscaleImage, 0 );
-		final Array selectedArray = openLevel( multiscaleImage, selectedResolutionLevelIndex );
 		final T type = typeForZarrDataType( level0Array.metadata().dataType().getMA2DataType() );
 		final V volatileType = Cast.unchecked( VolatileTypeMatcher.getVolatileTypeForType( type ) );
 
 		// zarr shape is C-order [t, c, z, y, x]; imglib2 uses F-order [x, y, z, c, t]
-		final long[] zarrShape = selectedArray.metadata().shape;
+		final long[] zarrShape = level0Array.metadata().shape;
 		final long[] dimensions = reverseToLong( zarrShape );
 		final int numDimensions = dimensions.length;
 
@@ -354,28 +342,6 @@ public class ZarrJavaPyramidBackend<
 		{
 			return 1;
 		}
-	}
-
-	private int selectResolutionLevelIndex( final MultiscaleImage multiscaleImage, final MultiscalesEntry entry,
-			final int numResolutionLevels, final Integer preferredMaxWidth )
-	{
-		if ( preferredMaxWidth == null )
-			return 0;
-
-		final int xAxis = zarrAxisIndex( entry.axes, AxisCalibration.X );
-		if ( xAxis < 0 )
-			return 0;
-
-		int smallestWidth = Integer.MAX_VALUE;
-		for ( int level = 0; level < numResolutionLevels; level++ )
-		{
-			final int width = ( int ) openLevel( multiscaleImage, level ).metadata().shape[ xAxis ];
-			if ( width <= preferredMaxWidth )
-				return level;
-			smallestWidth = Math.min( smallestWidth, width );
-		}
-
-		throw new NoMatchingResolutionException( preferredMaxWidth, smallestWidth );
 	}
 
 	private Array openLevel( final MultiscaleImage multiscaleImage, final int levelIndex )

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -94,7 +94,7 @@ import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
 /**
  * {@link PyramidBackend} that reads OME-Zarr images with the zarr-java library.
- * Supports OME-NGFF v0.4 (Zarr v2) and v0.5 (Zarr v3).
+ * Supports OME-Zarr v0.4 (Zarr v2) and v0.5 (Zarr v3).
  *
  * @param <T> pixel type
  * @param <V> volatile pixel type
@@ -453,7 +453,7 @@ public class ZarrJavaPyramidBackend<
 	}
 
 	/**
-	 * Returns the unit attached to the last x/y/z axis encountered. OME-NGFF
+	 * Returns the unit attached to the last x/y/z axis encountered. OME-Zarr
 	 * spatial axes share a single unit in well-formed datasets, so this
 	 * collapses to "the spatial unit"; the original loop happened to write
 	 * it last-wins, and this preserves that behavior.
@@ -517,7 +517,7 @@ public class ZarrJavaPyramidBackend<
 	 * array directly (instead of the library type with a nullable
 	 * {@code scale} field) keeps null-tracking local to this method, so
 	 * callers don't have to repeat the {@code scaleCt.scale != null} check.
-	 * OME-NGFF datasets carry at most one scale transformation per level,
+	 * OME-Zarr datasets carry at most one scale transformation per level,
 	 * so "first usable one" is observably equivalent to "first scale ct,
 	 * null-check at the call site".
 	 * <p>

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaPyramidBackend.java
@@ -34,8 +34,6 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,10 +55,6 @@ import dev.zarr.zarrjava.store.HttpStore;
 import dev.zarr.zarrjava.store.Store;
 import dev.zarr.zarrjava.store.StoreHandle;
 
-import net.imagej.ImgPlus;
-import net.imagej.axis.Axes;
-import net.imagej.axis.AxisType;
-import net.imagej.axis.DefaultLinearAxis;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.Volatile;
 import net.imglib2.cache.img.CachedCellImg;
@@ -95,6 +89,7 @@ import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.exceptions.PyramidLevelAccessException;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidBackend;
 import sc.fiji.ome.zarr.pyramid.backend.PyramidContents;
+import sc.fiji.ome.zarr.pyramid.metadata.AxisCalibration;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
 
 /**
@@ -110,19 +105,6 @@ public class ZarrJavaPyramidBackend<
 		implements PyramidBackend< T, V >
 {
 	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
-
-	private static final Map< String, AxisType > AXIS_MAPPING;
-
-	static
-	{
-		final Map< String, AxisType > map = new HashMap<>();
-		map.put( "x", Axes.X );
-		map.put( "y", Axes.Y );
-		map.put( "z", Axes.Z );
-		map.put( "c", Axes.CHANNEL );
-		map.put( "t", Axes.TIME );
-		AXIS_MAPPING = Collections.unmodifiableMap( map );
-	}
 
 	private final URI inputUri;
 
@@ -161,8 +143,8 @@ public class ZarrJavaPyramidBackend<
 		final long[] dimensions = reverseToLong( zarrShape );
 		final int numDimensions = dimensions.length;
 
-		final int numTimepoints = getDimSizeForAxis( entry.axes, zarrShape, "t" );
-		final int numChannels = getDimSizeForAxis( entry.axes, zarrShape, "c" );
+		final int numTimepoints = getDimSizeForAxis( entry.axes, zarrShape, AxisCalibration.T );
+		final int numChannels = getDimSizeForAxis( entry.axes, zarrShape, AxisCalibration.C );
 
 		final String name = entry.name != null ? entry.name : defaultName();
 		final double[] level0Scales = getLevel0Scales( entry, numDimensions );
@@ -181,15 +163,14 @@ public class ZarrJavaPyramidBackend<
 			volatileImgs[ level ] = VolatileViews.wrapAsVolatile( cachedCellImgs[ level ], sharedQueue );
 		}
 
-		final ImgPlus< T > imgPlus = new ImgPlus<>( cachedCellImgs[ selectedResolutionLevelIndex ], name );
-		configureImgPlusAxes( imgPlus, entry.axes, level0Scales );
+		final AxisCalibration[] axes = createAxisCalibrations( entry.axes, level0Scales );
 
 		final VoxelDimensions voxelDimensions = createVoxelDimensions( level0Scales, entry.axes );
 		final AffineTransform3D[] transforms = createTransforms( entry, numResolutionLevels, level0Scales );
 
-		final int channelAxisIndex = imglibAxisIndex( entry.axes, "c", numDimensions );
-		final int zAxisIndex = imglibAxisIndex( entry.axes, "z", numDimensions );
-		final int timeAxisIndex = imglibAxisIndex( entry.axes, "t", numDimensions );
+		final int channelAxisIndex = imglibAxisIndex( entry.axes, AxisCalibration.C, numDimensions );
+		final int zAxisIndex = imglibAxisIndex( entry.axes, AxisCalibration.Z, numDimensions );
+		final int timeAxisIndex = imglibAxisIndex( entry.axes, AxisCalibration.T, numDimensions );
 
 		final Omero omero = convertOmero( multiscaleImage.getOmeroMetadata() );
 		final String[] channelLabels = Omero.buildChannelLabels( name, omero, numChannels );
@@ -207,7 +188,7 @@ public class ZarrJavaPyramidBackend<
 				.transforms( transforms )
 				.cachedCellImgs( cachedCellImgs )
 				.volatileImgs( volatileImgs )
-				.imgPlus( imgPlus )
+				.axes( axes )
 				.channelAxisIndex( channelAxisIndex )
 				.zAxisPresent( zAxisIndex >= 0 )
 				.timeAxisPresent( timeAxisIndex >= 0 )
@@ -382,7 +363,7 @@ public class ZarrJavaPyramidBackend<
 		if ( preferredMaxWidth == null )
 			return 0;
 
-		final int xAxis = zarrAxisIndex( entry.axes, "x" );
+		final int xAxis = zarrAxisIndex( entry.axes, AxisCalibration.X );
 		if ( xAxis < 0 )
 			return 0;
 
@@ -459,9 +440,9 @@ public class ZarrJavaPyramidBackend<
 	{
 		if ( zarrAxes == null )
 			return new FinalVoxelDimensions( "", 1.0, 1.0, 1.0 );
-		final double xScale = scaleForNamedAxis( zarrAxes, level0Scales, "x" );
-		final double yScale = scaleForNamedAxis( zarrAxes, level0Scales, "y" );
-		final double zScale = scaleForNamedAxis( zarrAxes, level0Scales, "z" );
+		final double xScale = scaleForNamedAxis( zarrAxes, level0Scales, AxisCalibration.X );
+		final double yScale = scaleForNamedAxis( zarrAxes, level0Scales, AxisCalibration.Y );
+		final double zScale = scaleForNamedAxis( zarrAxes, level0Scales, AxisCalibration.Z );
 		return new FinalVoxelDimensions( spatialUnit( zarrAxes ), xScale, yScale, zScale );
 	}
 
@@ -482,7 +463,7 @@ public class ZarrJavaPyramidBackend<
 		String unit = "";
 		for ( final Axis axis : axes )
 		{
-			if ( "x".equals( axis.name ) || "y".equals( axis.name ) || "z".equals( axis.name ) )
+			if ( AxisCalibration.X.equals( axis.name ) || AxisCalibration.Y.equals( axis.name ) || AxisCalibration.Z.equals( axis.name ) )
 				unit = axis.unit == null ? "" : axis.unit;
 		}
 		return unit;
@@ -492,9 +473,9 @@ public class ZarrJavaPyramidBackend<
 			final int numResolutionLevels, final double[] level0Scales )
 	{
 		final int[] spatialZarrIdx = new int[] {
-				zarrAxisIndex( entry.axes, "x" ),
-				zarrAxisIndex( entry.axes, "y" ),
-				zarrAxisIndex( entry.axes, "z" )
+				zarrAxisIndex( entry.axes, AxisCalibration.X ),
+				zarrAxisIndex( entry.axes, AxisCalibration.Y ),
+				zarrAxisIndex( entry.axes, AxisCalibration.Z )
 		};
 		final AffineTransform3D[] tr = new AffineTransform3D[ numResolutionLevels ];
 		for ( int level = 0; level < numResolutionLevels; level++ )
@@ -587,20 +568,20 @@ public class ZarrJavaPyramidBackend<
 		return zarrIndex >= 0 && zarrIndex < level0Scales.length ? level0Scales[ zarrIndex ] : 1.0;
 	}
 
-	private static < T extends NativeType< T > & RealType< T > > void configureImgPlusAxes(
-			final ImgPlus< T > img, final List< Axis > zarrAxes, final double[] level0Scales )
+	private static AxisCalibration[] createAxisCalibrations( final List< Axis > zarrAxes, final double[] level0Scales )
 	{
 		if ( zarrAxes == null )
-			return;
+			return new AxisCalibration[ 0 ];
 		final int n = zarrAxes.size();
+		final AxisCalibration[] result = new AxisCalibration[ n ];
 		for ( int zarrDim = 0; zarrDim < n; zarrDim++ )
 		{
 			final int imgDim = n - 1 - zarrDim;
 			final Axis axis = zarrAxes.get( zarrDim );
-			final AxisType axisType = AXIS_MAPPING.getOrDefault( axis.name, Axes.unknown() );
 			final String unit = axis.unit != null ? axis.unit : "";
-			img.setAxis( new DefaultLinearAxis( axisType, unit, level0Scales[ zarrDim ] ), imgDim );
+			result[ imgDim ] = new AxisCalibration( axis.name, unit, level0Scales[ zarrDim ] );
 		}
+		return result;
 	}
 
 	// ---------------------------------------------------------------------

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/AxisCalibration.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/AxisCalibration.java
@@ -1,0 +1,70 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.metadata;
+
+/**
+ * Lightweight, framework-agnostic axis descriptor produced by a
+ * {@link sc.fiji.ome.zarr.pyramid.backend.PyramidBackend}. Carries just the
+ * information needed to calibrate one image dimension: a logical axis name
+ * (e.g. {@code "x"}, {@code "t"}), a physical unit string, and the pixel
+ * spacing at the selected resolution level.
+ */
+public final class AxisCalibration
+{
+	/** OME-NGFF axis name for the x (horizontal) spatial axis. */
+	public static final String X = "x";
+
+	/** OME-NGFF axis name for the y (vertical) spatial axis. */
+	public static final String Y = "y";
+
+	/** OME-NGFF axis name for the z (depth) spatial axis. */
+	public static final String Z = "z";
+
+	/** OME-NGFF axis name for the channel axis. */
+	public static final String C = "c";
+
+	/** OME-NGFF axis name for the time axis. */
+	public static final String T = "t";
+
+	/** Logical axis name as it appears in OME-NGFF metadata (e.g. "x", "y", "z", "c", "t"). */
+	public final String name;
+
+	/** Physical unit string, or an empty string when absent. */
+	public final String unit;
+
+	/** Pixel spacing at the selected resolution level in the given unit. */
+	public final double scale;
+
+	public AxisCalibration( final String name, final String unit, final double scale )
+	{
+		this.name = name;
+		this.unit = unit;
+		this.scale = scale;
+	}
+}

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/AxisCalibration.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/metadata/AxisCalibration.java
@@ -37,22 +37,22 @@ package sc.fiji.ome.zarr.pyramid.metadata;
  */
 public final class AxisCalibration
 {
-	/** OME-NGFF axis name for the x (horizontal) spatial axis. */
+	/** OME-Zarr axis name for the x (horizontal) spatial axis. */
 	public static final String X = "x";
 
-	/** OME-NGFF axis name for the y (vertical) spatial axis. */
+	/** OME-Zarr axis name for the y (vertical) spatial axis. */
 	public static final String Y = "y";
 
-	/** OME-NGFF axis name for the z (depth) spatial axis. */
+	/** OME-Zarr axis name for the z (depth) spatial axis. */
 	public static final String Z = "z";
 
-	/** OME-NGFF axis name for the channel axis. */
+	/** OME-Zarr axis name for the channel axis. */
 	public static final String C = "c";
 
-	/** OME-NGFF axis name for the time axis. */
+	/** OME-Zarr axis name for the time axis. */
 	public static final String T = "t";
 
-	/** Logical axis name as it appears in OME-NGFF metadata (e.g. "x", "y", "z", "c", "t"). */
+	/** Logical axis name as it appears in OME-Zarr metadata (e.g. "x", "y", "z", "c", "t"). */
 	public final String name;
 
 	/** Physical unit string, or an empty string when absent. */

--- a/src/test/java/sc/fiji/ome/zarr/examples/BigStitcherStyleOMEZarrReader.java
+++ b/src/test/java/sc/fiji/ome/zarr/examples/BigStitcherStyleOMEZarrReader.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -63,7 +63,7 @@ public class BigStitcherStyleOMEZarrReader
 {
 
 	/**
-	 * Reads OME-Zarr metadata following the OME-NGFF v0.4 specification.
+	 * Reads OME-Zarr metadata following the OME-Zarr v0.4 specification.
 	 * This is how BigDataViewer/MoBIE parse OME-Zarr metadata.
 	 */
 	public static class OMEZarrMetadata
@@ -149,7 +149,7 @@ public class BigStitcherStyleOMEZarrReader
 	}
 
 	/**
-	 * Parses OME-NGFF metadata from the root .zattrs file.
+	 * Parses OME-Zarr metadata from the root .zattrs file.
 	 * This follows the pattern used by bigdataviewer-omezarr.
 	 */
 	private static OMEZarrMetadata parseOMEZarrMetadata( N5Reader n5 ) throws IOException

--- a/src/test/java/sc/fiji/ome/zarr/examples/BigStitcherStyleOMEZarrWriter.java
+++ b/src/test/java/sc/fiji/ome/zarr/examples/BigStitcherStyleOMEZarrWriter.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -64,7 +64,7 @@ public class BigStitcherStyleOMEZarrWriter
 {
 
 	/**
-	 * Writes a multi-scale OME-Zarr following OME-NGFF v0.4 specification.
+	 * Writes a multi-scale OME-Zarr following OME-Zarr v0.4 specification.
 	 * This is how BigStitcher-Spark creates OME-Zarr fusion output.
 	 */
 	public static class OMEZarrWriter
@@ -100,8 +100,8 @@ public class BigStitcherStyleOMEZarrWriter
 		}
 
 		/**
-		 * Write a multiscale pyramid with proper OME-NGFF metadata. This follows BigStitcher-Spark's approach.<br>
-		 * Writes a multiscale dataset to a Zarr-compatible format with OME-NGFF v0.4 metadata.
+		 * Write a multiscale pyramid with proper OME-Zarr metadata. This follows BigStitcher-Spark's approach.<br>
+		 * Writes a multiscale dataset to a Zarr-compatible format with OME-Zarr v0.4 metadata.
 		 * The method saves multiple resolution levels, each corresponding to a downsampled
 		 * version of the provided input, and writes the corresponding metadata necessary
 		 * for OME-Zarr compliance.
@@ -152,7 +152,7 @@ public class BigStitcherStyleOMEZarrWriter
 						Arrays.toString( scales[ level ].dimensionsAsLongArray() ) );
 			}
 
-			// Write OME-NGFF v0.4 metadata
+			// Write OME-Zarr v0.4 metadata
 			writeOMEMetadata(
 					scales,
 					voxelSizes,
@@ -164,8 +164,8 @@ public class BigStitcherStyleOMEZarrWriter
 		}
 
 		/**
-		 * Writes OME-NGFF v0.4 compliant metadata to root .zattrs. This is the key method for proper OME-Zarr compliance.<br>
-		 * Writes OME-NGFF metadata to the Zarr dataset. This method generates metadata in compliance
+		 * Writes OME-Zarr v0.4 compliant metadata to root .zattrs. This is the key method for proper OME-Zarr compliance.<br>
+		 * Writes OME-Zarr metadata to the Zarr dataset. This method generates metadata in compliance
 		 * with the OME-Zarr specification (version 0.4) and writes it alongside the multiscale datasets.
 		 * The metadata includes information about axes, resolutions, and transformations, and optionally
 		 * adds OMERO metadata or other user-defined attributes.
@@ -200,7 +200,7 @@ public class BigStitcherStyleOMEZarrWriter
 
 			JsonObject rootAttrs = new JsonObject();
 
-			// Create multiscales array (OME-NGFF v0.4)
+			// Create multiscales array (OME-Zarr v0.4)
 			JsonArray multiscales = new JsonArray();
 			JsonObject multiscale = new JsonObject();
 
@@ -421,7 +421,7 @@ public class BigStitcherStyleOMEZarrWriter
 					{ 2.0, 2.0, 1.0, 1.0, 1.0 } // Level 2 (4x in x,y)
 			};
 
-			// Define axes following OME-NGFF convention
+			// Define axes following OME-Zarr convention
 			String[] axisNames = { "t", "c", "z", "y", "x" };
 			String[] axisTypes = { "time", "channel", "space", "space", "space" };
 			String[] axisUnits = { null, null, "micrometer", "micrometer", "micrometer" };

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5BackedPyramidal5DImageDataTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5BackedPyramidal5DImageDataTest.java
@@ -45,6 +45,6 @@ public class N5BackedPyramidal5DImageDataTest implements Pyramidal5DImageDataTes
 			throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( resource );
-		return new Pyramidal5DImageDataImpl<>( context, new N5PyramidBackend( path.toUri(), preferredWidth ), preferredWidth );
+		return new Pyramidal5DImageDataImpl<>( context, new N5PyramidBackend( path.toUri() ), preferredWidth );
 	}
 }

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5BackedPyramidal5DImageDataTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5BackedPyramidal5DImageDataTest.java
@@ -45,6 +45,6 @@ public class N5BackedPyramidal5DImageDataTest implements Pyramidal5DImageDataTes
 			throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( resource );
-		return new Pyramidal5DImageDataImpl<>( context, new N5PyramidBackend( path.toUri(), preferredWidth ) );
+		return new Pyramidal5DImageDataImpl<>( context, new N5PyramidBackend( path.toUri(), preferredWidth ), preferredWidth );
 	}
 }

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaBackedPyramidal5DImageDataTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaBackedPyramidal5DImageDataTest.java
@@ -45,6 +45,6 @@ public class ZarrJavaBackedPyramidal5DImageDataTest implements Pyramidal5DImageD
 			throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( resource );
-		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( path.toUri(), preferredWidth ) );
+		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( path.toUri(), preferredWidth ), preferredWidth );
 	}
 }

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaBackedPyramidal5DImageDataTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/backend/zarrjava/ZarrJavaBackedPyramidal5DImageDataTest.java
@@ -45,6 +45,6 @@ public class ZarrJavaBackedPyramidal5DImageDataTest implements Pyramidal5DImageD
 			throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( resource );
-		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( path.toUri(), preferredWidth ), preferredWidth );
+		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( path.toUri() ), preferredWidth );
 	}
 }


### PR DESCRIPTION
Resolves https://github.com/BioImageTools/ome-zarr-fiji-java/issues/73

## Summary

`PyramidContents.imgPlus` was only ever consumed by `Pyramidal5DImageDataImpl` to construct an ImageJ `Dataset`. This PR removes it and replaces it with a lightweight `AxisCalibration[]`, decoupling the `backend` package entirely from `net.imagej`.

- **Add `AxisCalibration`** to `sc.fiji.ome.zarr.pyramid.metadata` — a minimal, dependency-free axis descriptor (`name`, `unit`, `scale`) with named constants `X`, `Y`, `Z`, `C`, `T` for the OME-NGFF axis names. Lives alongside `Omero` as both are OME-Zarr metadata objects produced by backends.
- **Remove `imgPlus` from `PyramidContents`** — replaced by `AxisCalibration[]`. The `backend` package now has zero `net.imagej` imports.
- **Refactor backends** — `N5PyramidBackend` and `ZarrJavaPyramidBackend` produce `AxisCalibration[]` directly. `findAxisIndex`/`getAxisSize` in `N5PyramidBackend` now take a `String` axis name instead of `AxisType`. All axis string literals replaced with named constants.
- **Move `ImgPlus` construction to `Pyramidal5DImageDataImpl`** — builds the `ImgPlus` from `cachedCellImgs[selectedResolutionLevelIndex]` and `AxisCalibration[]`, keeping all `net.imagej` knowledge in the one class that is allowed to depend on it.

## Motivation

* The goal is to eventually publish the `backend` package as a separate artefact usable by other Java-based image analysis tools that may not depend on `net.imagej` - cf. https://github.com/BioImageTools/ome-zarr-fiji-java/issues/72
* Even after merging in PR, there is still a remaining dependency on `mpicbg.spim.data.sequence.VoxelDimensions`, which comes from `sc.fiji.spim_data`. However, this will be part of separate PR.

## Test plan

- [x] `mvn clean package` passes (all existing tests green)