### PR TITLE
Simplify Pyramidal5DImageData open API

### DIFF
--- a/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
@@ -55,16 +55,14 @@ import net.imglib2.util.Cast;
 
 import bdv.util.BdvFunctions;
 import ij.IJ;
-import sc.fiji.ome.zarr.pyramid.Pyramidal5DImageDataImpl;
+import sc.fiji.ome.zarr.pyramid.Pyramidal5DImageData;
 import sc.fiji.ome.zarr.pyramid.exceptions.MultiImageDatasetException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NotAMultiscaleImageException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NotASingleScaleImageException;
 import sc.fiji.ome.zarr.pyramid.PyramidalDataset;
-import sc.fiji.ome.zarr.pyramid.backend.zarrjava.ZarrJavaPyramidBackend;
 import sc.fiji.ome.zarr.open.options.ZarrOpeningSettings;
 import sc.fiji.ome.zarr.open.options.ZarrOpenBehavior;
-import sc.fiji.ome.zarr.open.options.ZarrReaderBackend;
 import sc.fiji.ome.zarr.ui.DnDActionChooser;
 import sc.fiji.ome.zarr.util.BdvUtils;
 import sc.fiji.ome.zarr.util.ScriptUtils;
@@ -265,35 +263,10 @@ public class ZarrOpenActions
 	private Object openMultiScaleImage( final Function< PyramidalDataset< ? >, Object > multiScaleImageOpener )
 			throws NotAMultiscaleImageException, NoMatchingResolutionException
 	{
-		final Integer preferredWidth;
-		if ( settings == null || settings.getOpenBehavior().equals( ZarrOpenBehavior.IMAGEJ_HIGHEST_RESOLUTION ) )
-			preferredWidth = null;
-		else
-			preferredWidth = settings.getPreferredMaxWidth();
-
-		final ZarrReaderBackend backend = settings == null
-				? ZarrOpeningSettings.DEFAULT_READER_BACKEND
-				: settings.getReaderBackend();
-
-		final Pyramidal5DImageDataImpl< ?, ? > data;
-		switch ( backend )
-		{
-		case ZARR_JAVA:
-		{
-			@SuppressWarnings( { "rawtypes", "unchecked" } )
-			final Pyramidal5DImageDataImpl< ?, ? > zarrJavaData =
-					new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( inputUri, preferredWidth ) );
-			data = zarrJavaData;
-			break;
-		}
-		case N5:
-		default:
-			data = new Pyramidal5DImageDataImpl<>( context, inputUri, preferredWidth );
-			break;
-		}
-
+		final ZarrOpeningSettings effectiveSettings = settings != null ? settings : ZarrOpeningSettings.defaultSettings();
+		final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, inputUri, effectiveSettings );
 		final Object result = multiScaleImageOpener.apply( data.asPyramidalDataset() );
-		logger.info( "Opened multiscale image with {} backend: {}", backend, inputUri );
+		logger.info( "Opened multiscale image with {} backend: {}", effectiveSettings.getReaderBackend(), inputUri );
 		return result;
 	}
 

--- a/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
+++ b/src/main/java/sc/fiji/ome/zarr/open/ZarrOpenActions.java
@@ -109,12 +109,12 @@ public class ZarrOpenActions
 		}
 	}
 
-	public ZarrOpenActions( final URI inputUri, final Context context )
+	ZarrOpenActions( final URI inputUri, final Context context )
 	{
 		this( inputUri, context, null, IJ::error );
 	}
 
-	public ZarrOpenActions( final URI inputUri, final Context context, final ZarrOpeningSettings settings )
+	ZarrOpenActions( final URI inputUri, final Context context, final ZarrOpeningSettings settings )
 	{
 		this( inputUri, context, settings, IJ::error );
 	}

--- a/src/main/java/sc/fiji/ome/zarr/open/options/ZarrOpeningSettings.java
+++ b/src/main/java/sc/fiji/ome/zarr/open/options/ZarrOpeningSettings.java
@@ -125,6 +125,25 @@ public class ZarrOpeningSettings
 	}
 
 	/**
+	 * Returns a new {@link ZarrOpeningSettings} instance with all fields set to
+	 * their default values.
+	 */
+	public static ZarrOpeningSettings defaultSettings()
+	{
+		return new ZarrOpeningSettings();
+	}
+
+	/**
+	 * Returns the preferred width to pass to the pyramid backend based on
+	 * the configured opening behavior: {@code null} selects the highest
+	 * available resolution; any other behavior uses {@link #getPreferredMaxWidth()}.
+	 */
+	public Integer effectivePreferredWidth()
+	{
+		return ZarrOpenBehavior.IMAGEJ_HIGHEST_RESOLUTION.equals( zarrOpenBehavior ) ? null : preferredMaxWidth;
+	}
+
+	/**
 	 * Loads and returns the settings from the provided preference store.
 	 *
 	 * @param prefs If {@code null} is provided, default settings values from this class are used and returned.

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
@@ -39,8 +39,8 @@ import bdv.viewer.SourceAndConverter;
 import ij.ImagePlus;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import org.scijava.Context;
-import org.scijava.prefs.PrefService;
 
+import sc.fiji.ome.zarr.pyramid.exceptions.BackendMismatchException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
 import sc.fiji.ome.zarr.pyramid.backend.zarrjava.ZarrJavaPyramidBackend;
 import sc.fiji.ome.zarr.pyramid.metadata.Omero;
@@ -108,31 +108,55 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	}
 
 	/**
-	 * Opens an OME-Zarr image using the backend configured in the context's
-	 * {@link ZarrOpeningSettings}, falling back to the N5 backend if no
-	 * settings service is present.
+	 * Opens an OME-Zarr image using the backend specified by
+	 * {@link ZarrOpeningSettings#defaultSettings()}.
 	 *
 	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
 	 *   local datasets or an {@code http(s):} URI for remote datasets
-	 * @param preferredWidth maximum width along x for the returned dataset;
-	 *   {@code null} selects the highest available resolution
-	 * @throws NoMatchingResolutionException if {@code preferredWidth} is smaller
-	 *   than the width of the coarsest resolution level
+	 * @throws NoMatchingResolutionException if the effective preferred width
+	 *   from the default settings is smaller than the coarsest resolution level
 	 */
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > open(
-			final Context context, final URI uri, final Integer preferredWidth )
+			final Context context, final URI uri )
 	{
-		final ZarrReaderBackend backend = ZarrOpeningSettings
-				.loadSettingsFromPreferences( context.getService( PrefService.class ) )
-				.getReaderBackend();
-		switch ( backend )
+		return open( context, uri, ZarrOpeningSettings.defaultSettings() );
+	}
+
+	/**
+	 * Opens an OME-Zarr image using the backend and width configured in
+	 * {@code settings}.
+	 *
+	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
+	 *   local datasets or an {@code http(s):} URI for remote datasets
+	 * @param settings controls which backend and resolution level to use
+	 * @throws NoMatchingResolutionException if {@link ZarrOpeningSettings#effectivePreferredWidth()}
+	 *   is smaller than the width of the coarsest resolution level
+	 */
+	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > open(
+			final Context context, final URI uri, final ZarrOpeningSettings settings )
+	{
+		switch ( settings.getReaderBackend() )
 		{
 		case ZARR_JAVA:
-			return openWithZarrJava( context, uri, preferredWidth );
+			return openWithZarrJava( context, uri, settings );
 		case N5:
 		default:
-			return openWithN5( context, uri, preferredWidth );
+			return openWithN5( context, uri, settings );
 		}
+	}
+
+	/**
+	 * Opens an OME-Zarr image using the N5-universe backend with default settings.
+	 *
+	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
+	 *   local datasets or an {@code http(s):} URI for remote datasets
+	 * @throws NoMatchingResolutionException if the effective preferred width
+	 *   from the default settings is smaller than the coarsest resolution level
+	 */
+	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithN5(
+			final Context context, final URI uri )
+	{
+		return openWithN5( context, uri, ZarrOpeningSettings.defaultSettings() );
 	}
 
 	/**
@@ -140,15 +164,33 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	 *
 	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
 	 *   local datasets or an {@code http(s):} URI for remote datasets
-	 * @param preferredWidth maximum width along x for the returned dataset;
-	 *   {@code null} selects the highest available resolution
-	 * @throws NoMatchingResolutionException if {@code preferredWidth} is smaller
-	 *   than the width of the coarsest resolution level
+	 * @param settings controls the resolution level to use; the backend field
+	 *   must be {@link ZarrReaderBackend#N5}
+	 * @throws BackendMismatchException if {@code settings} specifies a backend
+	 *   other than N5
+	 * @throws NoMatchingResolutionException if {@link ZarrOpeningSettings#effectivePreferredWidth()}
+	 *   is smaller than the width of the coarsest resolution level
 	 */
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithN5(
-			final Context context, final URI uri, final Integer preferredWidth )
+			final Context context, final URI uri, final ZarrOpeningSettings settings )
 	{
-		return new Pyramidal5DImageDataImpl<>( context, uri, preferredWidth );
+		if ( settings.getReaderBackend() != ZarrReaderBackend.N5 )
+			throw new BackendMismatchException( ZarrReaderBackend.N5, settings.getReaderBackend() );
+		return new Pyramidal5DImageDataImpl<>( context, uri, settings.effectivePreferredWidth() );
+	}
+
+	/**
+	 * Opens an OME-Zarr image using the zarr-java backend with default settings.
+	 *
+	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
+	 *   local datasets or an {@code http(s):} URI for remote datasets
+	 * @throws NoMatchingResolutionException if the effective preferred width
+	 *   from the default settings is smaller than the coarsest resolution level
+	 */
+	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithZarrJava(
+			final Context context, final URI uri )
+	{
+		return openWithZarrJava( context, uri, ZarrOpeningSettings.defaultSettings() );
 	}
 
 	/**
@@ -156,15 +198,19 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	 *
 	 * @param uri location of the OME-Zarr root; either a {@code file:} URI for
 	 *   local datasets or an {@code http(s):} URI for remote datasets
-	 * @param preferredWidth maximum width along x for the returned dataset;
-	 *   {@code null} selects the highest available resolution
-	 * @throws NoMatchingResolutionException if {@code preferredWidth} is smaller
-	 *   than the width of the coarsest resolution level
+	 * @param settings controls the resolution level to use; the backend field
+	 *   must be {@link ZarrReaderBackend#ZARR_JAVA}
+	 * @throws BackendMismatchException if {@code settings} specifies a backend
+	 *   other than ZARR_JAVA
+	 * @throws NoMatchingResolutionException if {@link ZarrOpeningSettings#effectivePreferredWidth()}
+	 *   is smaller than the width of the coarsest resolution level
 	 */
 	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithZarrJava(
-			final Context context, final URI uri, final Integer preferredWidth )
+			final Context context, final URI uri, final ZarrOpeningSettings settings )
 	{
-		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri, preferredWidth ) );
+		if ( settings.getReaderBackend() != ZarrReaderBackend.ZARR_JAVA )
+			throw new BackendMismatchException( ZarrReaderBackend.ZARR_JAVA, settings.getReaderBackend() );
+		return new Pyramidal5DImageDataImpl( context, new ZarrJavaPyramidBackend( uri, settings.effectivePreferredWidth() ) );
 	}
 }

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageData.java
@@ -156,7 +156,7 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithN5(
 			final Context context, final URI uri )
 	{
-		return openWithN5( context, uri, ZarrOpeningSettings.defaultSettings() );
+		return new Pyramidal5DImageDataImpl<>( context, uri, ZarrOpeningSettings.defaultSettings().effectivePreferredWidth() );
 	}
 
 	/**
@@ -187,10 +187,12 @@ public interface Pyramidal5DImageData< T extends NativeType< T > & RealType< T >
 	 * @throws NoMatchingResolutionException if the effective preferred width
 	 *   from the default settings is smaller than the coarsest resolution level
 	 */
+	@SuppressWarnings( { "rawtypes", "unchecked" } )
 	static < T extends NativeType< T > & RealType< T > > Pyramidal5DImageData< T > openWithZarrJava(
 			final Context context, final URI uri )
 	{
-		return openWithZarrJava( context, uri, ZarrOpeningSettings.defaultSettings() );
+		return new Pyramidal5DImageDataImpl( context,
+				new ZarrJavaPyramidBackend( uri, ZarrOpeningSettings.defaultSettings().effectivePreferredWidth() ) );
 	}
 
 	/**

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/BackendMismatchException.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/exceptions/BackendMismatchException.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package sc.fiji.ome.zarr.pyramid.exceptions;
+
+import sc.fiji.ome.zarr.open.options.ZarrReaderBackend;
+
+/**
+ * Thrown when the {@link ZarrReaderBackend} specified in
+ * {@code ZarrOpeningSettings} contradicts the backend implied by the called
+ * factory method, e.g. calling {@code Pyramidal5DImageData.openWithN5()} while
+ * settings carry {@code ZarrReaderBackend.ZARR_JAVA}.
+ */
+public class BackendMismatchException extends IllegalArgumentException
+{
+	public BackendMismatchException( final ZarrReaderBackend expected, final ZarrReaderBackend actual )
+	{
+		super( "Expected backend " + expected + " but ZarrOpeningSettings specifies " + actual
+				+ ". Use open() to dispatch by the settings' backend, or align the settings with the called method." );
+	}
+}

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataAsImagePlusTest.java
@@ -59,7 +59,7 @@ class Pyramidal5DImageDataAsImagePlusTest
 
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > pyramidal5DImageData = Pyramidal5DImageData.openWithN5( context, path.toUri(), null );
+			final Pyramidal5DImageData< ? > pyramidal5DImageData = Pyramidal5DImageData.openWithN5( context, path.toUri() );
 			final ImagePlus imagePlus = pyramidal5DImageData.asImagePlus();
 
 			assertNotNull( imagePlus );

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataOpenTest.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/Pyramidal5DImageDataOpenTest.java
@@ -38,21 +38,22 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
 import org.scijava.Context;
-import org.scijava.prefs.PrefService;
 
 import sc.fiji.ome.zarr.pyramid.backend.n5.N5BackedPyramidal5DImageDataTest;
 import sc.fiji.ome.zarr.pyramid.backend.zarrjava.ZarrJavaBackedPyramidal5DImageDataTest;
+import sc.fiji.ome.zarr.pyramid.exceptions.BackendMismatchException;
 import sc.fiji.ome.zarr.pyramid.exceptions.NoMatchingResolutionException;
+import sc.fiji.ome.zarr.open.options.ZarrOpenBehavior;
 import sc.fiji.ome.zarr.open.options.ZarrOpeningSettings;
 import sc.fiji.ome.zarr.open.options.ZarrReaderBackend;
 import sc.fiji.ome.zarr.util.ZarrTestUtils;
 
 /**
- * Unit tests for the three static factory methods on
+ * Unit tests for the static factory methods on
  * {@link Pyramidal5DImageData}: {@link Pyramidal5DImageData#openWithN5},
  * {@link Pyramidal5DImageData#openWithZarrJava}, and
- * {@link Pyramidal5DImageData#open} (which dispatches based on the user's
- * configured {@link ZarrReaderBackend}).
+ * {@link Pyramidal5DImageData#open} (which dispatches based on the
+ * {@link ZarrReaderBackend} in the provided {@link ZarrOpeningSettings}).
  * <p>
  * Backend-internal correctness (axis handling, omero metadata, pyramid
  * reading, etc.) is covered by {@link N5BackedPyramidal5DImageDataTest}
@@ -70,7 +71,7 @@ class Pyramidal5DImageDataOpenTest
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithN5( context, path.toUri(), null );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithN5( context, path.toUri() );
 			assertWorkingDataset( data );
 		}
 	}
@@ -83,7 +84,8 @@ class Pyramidal5DImageDataOpenTest
 		{
 			// preferredWidth=50 fits the second pyramid level (32 px), not the
 			// full-resolution one (64 px), so the returned dataset is 32x32.
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithN5( context, path.toUri(), 50 );
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION, 50 );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithN5( context, path.toUri(), settings );
 			assertEquals( 32, data.asDataset().getImgPlus().dimension( 0 ) );
 			assertEquals( 32, data.asDataset().getImgPlus().dimension( 1 ) );
 		}
@@ -95,8 +97,22 @@ class Pyramidal5DImageDataOpenTest
 		final URI pathUri = ZarrTestUtils.resourcePath( TEST_RESOURCE ).toUri();
 		try (Context context = new Context())
 		{
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION, 16 );
 			assertThrows( NoMatchingResolutionException.class,
-					() -> Pyramidal5DImageData.openWithN5( context, pathUri, 16 ) );
+					() -> Pyramidal5DImageData.openWithN5( context, pathUri, settings ) );
+		}
+	}
+
+	@Test
+	void testOpenWithN5ThrowsOnZarrJavaBackendSettings() throws URISyntaxException
+	{
+		final URI pathUri = ZarrTestUtils.resourcePath( TEST_RESOURCE ).toUri();
+		try (Context context = new Context())
+		{
+			final ZarrOpeningSettings settings = ZarrOpeningSettings.defaultSettings();
+			settings.setReaderBackend( ZarrReaderBackend.ZARR_JAVA );
+			assertThrows( BackendMismatchException.class,
+					() -> Pyramidal5DImageData.openWithN5( context, pathUri, settings ) );
 		}
 	}
 
@@ -106,7 +122,7 @@ class Pyramidal5DImageDataOpenTest
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithZarrJava( context, path.toUri(), null );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithZarrJava( context, path.toUri() );
 			assertWorkingDataset( data );
 		}
 	}
@@ -117,7 +133,9 @@ class Pyramidal5DImageDataOpenTest
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithZarrJava( context, path.toUri(), 50 );
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION, 50 );
+			settings.setReaderBackend( ZarrReaderBackend.ZARR_JAVA );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.openWithZarrJava( context, path.toUri(), settings );
 			assertEquals( 32, data.asDataset().getImgPlus().dimension( 0 ) );
 			assertEquals( 32, data.asDataset().getImgPlus().dimension( 1 ) );
 		}
@@ -129,8 +147,22 @@ class Pyramidal5DImageDataOpenTest
 		final URI pathUri = ZarrTestUtils.resourcePath( TEST_RESOURCE ).toUri();
 		try (Context context = new Context())
 		{
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION, 16 );
+			settings.setReaderBackend( ZarrReaderBackend.ZARR_JAVA );
 			assertThrows( NoMatchingResolutionException.class,
-					() -> Pyramidal5DImageData.openWithZarrJava( context, pathUri, 16 ) );
+					() -> Pyramidal5DImageData.openWithZarrJava( context, pathUri, settings ) );
+		}
+	}
+
+	@Test
+	void testOpenWithZarrJavaThrowsOnN5BackendSettings() throws URISyntaxException
+	{
+		final URI pathUri = ZarrTestUtils.resourcePath( TEST_RESOURCE ).toUri();
+		try (Context context = new Context())
+		{
+			final ZarrOpeningSettings settings = ZarrOpeningSettings.defaultSettings(); // N5 by default
+			assertThrows( BackendMismatchException.class,
+					() -> Pyramidal5DImageData.openWithZarrJava( context, pathUri, settings ) );
 		}
 	}
 
@@ -140,8 +172,9 @@ class Pyramidal5DImageDataOpenTest
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			persistBackendChoice( context, ZarrReaderBackend.N5 );
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri(), null );
+			final ZarrOpeningSettings settings = ZarrOpeningSettings.defaultSettings();
+			settings.setReaderBackend( ZarrReaderBackend.N5 );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri(), settings );
 			assertWorkingDataset( data );
 		}
 	}
@@ -152,35 +185,26 @@ class Pyramidal5DImageDataOpenTest
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			persistBackendChoice( context, ZarrReaderBackend.ZARR_JAVA );
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri(), null );
+			final ZarrOpeningSettings settings = ZarrOpeningSettings.defaultSettings();
+			settings.setReaderBackend( ZarrReaderBackend.ZARR_JAVA );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri(), settings );
 			assertWorkingDataset( data );
 		}
 	}
 
 	@Test
-	void testOpenWithFreshContextUsesDefaultBackend() throws URISyntaxException
+	void testOpenWithDefaultSettingsUsesN5Backend() throws URISyntaxException
 	{
-		// No prefs written → loadSettingsFromPreferences falls back to the
-		// project's DEFAULT_READER_BACKEND, and open() must succeed.
 		final Path path = ZarrTestUtils.resourcePath( TEST_RESOURCE );
 		try (Context context = new Context())
 		{
-			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri(), null );
+			final Pyramidal5DImageData< ? > data = Pyramidal5DImageData.open( context, path.toUri() );
 			assertWorkingDataset( data );
 		}
 	}
 
-	private static void persistBackendChoice( final Context context, final ZarrReaderBackend backend )
-	{
-		final PrefService prefs = context.getService( PrefService.class );
-		final ZarrOpeningSettings settings = ZarrOpeningSettings.loadSettingsFromPreferences( prefs );
-		settings.setReaderBackend( backend );
-		settings.saveSettingsToPreferences( prefs );
-	}
-
 	/**
-	 * Sanity assertions that any of the three open() methods must satisfy
+	 * Sanity assertions that any of the open() methods must satisfy
 	 * for our 5D test dataset (64x64x16, 3 channels, 4 timepoints, 2 levels).
 	 */
 	private static void assertWorkingDataset( final Pyramidal5DImageData< ? > data )


### PR DESCRIPTION
## Summary

- Replace `(Context, URI, Integer preferredWidth)` factory-method signatures on `Pyramidal5DImageData` with `(Context, URI)` (no-settings) and `(Context, URI, ZarrOpeningSettings)` overloads, removing the raw `Integer preferredWidth` parameter from the public API
- Add `ZarrOpeningSettings.defaultSettings()` factory method and `effectivePreferredWidth()` helper, which encapsulate the "null width for highest resolution" logic that was previously scattered across callers
- Add `BackendMismatchException` (unchecked) thrown when `openWithN5`/`openWithZarrJava` receive settings that specify the wrong backend, making misuse of the specific-backend methods fail fast with a clear message
- Simplify `ZarrOpenActions.openMultiScaleImage()` to delegate entirely to `Pyramidal5DImageData.open()`, removing the inline switch on backend
- Remove the `PrefService` look-up from `Pyramidal5DImageData.open()`; settings are now passed in by the caller rather than read from persisted preferences inside the factory method
- Make `ZarrOpenActions` constructors package-private (they were only ever called from within the package)

## Test plan

- [ ] `mvn test` passes (all existing tests updated to new API, new `BackendMismatchException` tests added)
- [ ] `testOpenWithN5ThrowsOnZarrJavaBackendSettings` – `openWithN5` rejects ZARR_JAVA settings
- [ ] `testOpenWithZarrJavaThrowsOnN5BackendSettings` – `openWithZarrJava` rejects N5 settings
- [ ] `testOpenWithDefaultSettingsUsesN5Backend` – no-arg `open()` uses N5 as default
- [ ] `testOpenWithPreferredWidthN5` / `testOpenWithPreferredWidthZarrJava` – resolution selection still works via settings