### PR TITLE
Update n5 dependencies in `pom.xml` to their latest stable release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This repo is currently primarily a Fiji Drag & Drop / Copy & Paste handler for OME-Zarrs.
 
-If the dropped / pasted target is not recognized as a **OME-Zarr v0.4 - v0.5** resource, it does nothing.
+If the dropped / pasted target is not recognized as a **OME-Zarr v0.3 - v0.5** resource, it does nothing.
 
 # Features
 
@@ -67,6 +67,7 @@ and easily handles even the huge ones.
 
 * [OME-Zarr v0.5](https://ngff.openmicroscopy.org/0.5/index.html) (Zarr v3)
 * [OME-Zarr v0.4](https://ngff.openmicroscopy.org/0.4/index.html) (Zarr v2)
+* [OME-Zarr v0.3](https://ngff.openmicroscopy.org/0.3/index.html) (Zarr v2)
 * Supports 2D (xy), 3D (xyc, xyt, xyz), 4D (xyct, xyzc, xyzt) and 5D (xyzct) images.
 
 ## Dual dataset view
@@ -101,8 +102,9 @@ We support two backends for reading OME-Zarrs. Users can choose between the two 
 `Plugins -> OME-Zarr -> Settings -> Open Behavior settings` menu.
 
 * [N5 library](https://github.com/saalfeldlab/n5) (default)
-* [Zarr-java](https://github.com/zarr-developers/zarr-java) (alternative, may be a bit quicker when opening remote
-  resources).
+* [Zarr-java](https://github.com/zarr-developers/zarr-java)
+    * alternative, may be a bit quicker when opening remote resources.
+    * only supports OME-Zarr v0.4 and v0.5, not v0.3.
 
 ## Scriplet support
 
@@ -112,7 +114,8 @@ We support two backends for reading OME-Zarrs. Users can choose between the two 
 
 # Known issues
 
-* Reading of OME-Zarrs version <= 0.3 is not supported.
+* Reading of OME-Zarrs version <= 0.2 is not supported. With the zarr-java backend, only OME-Zarr v0.4 and v0.5 are
+  supported, not v0.3.
 * With FIJI stable, OME-Zarrs that use Blosc compression cannot be opened on MacOS. Please use FIJI latest, if you
   encounter this issue. Cf. [FIJI downloads](https://imagej.net/software/fiji/downloads).
 * In FIJI stable, Pasting a URI via `CMD` / `SHIFT` / `CTRL` + `V` is not supported. Please use FIJI latest.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -152,17 +153,17 @@
 		<license.copyrightOwners>SciJava developers</license.copyrightOwners>
 		<license.excludes>**/zarr.json</license.excludes>
 
-		<n5.version>4.0.0-alpha-12</n5.version>
-		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
-		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
-		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
-		<n5-hdf5>2.3.0-alpha-7</n5-hdf5>
-		<n5-ij.version>4.5.0-alpha-7</n5-ij.version>
-		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
-		<n5-universe.version>2.4.0-alpha-9</n5-universe.version>
-		<n5-viewer_fiji.version>6.2.0-alpha-5</n5-viewer_fiji.version>
-		<n5-zarr.version>2.0.0-alpha-8</n5-zarr.version>
-		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
+		<n5.version>4.0.0</n5.version>
+		<n5-aws-s3.version>5.0.0</n5-aws-s3.version>
+		<n5-blosc.version>2.0.0</n5-blosc.version>
+		<n5-google-cloud.version>6.0.0</n5-google-cloud.version>
+		<n5-hdf5>3.0.0</n5-hdf5>
+		<n5-ij.version>5.0.0</n5-ij.version>
+		<n5-imglib2.version>8.0.0</n5-imglib2.version>
+		<n5-universe.version>3.0.0</n5-universe.version>
+		<n5-viewer_fiji.version>6.2.0</n5-viewer_fiji.version>
+		<n5-zarr.version>2.0.0</n5-zarr.version>
+		<n5-zstandard.version>2.0.0</n5-zstandard.version>
 
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>

--- a/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
+++ b/src/main/java/sc/fiji/ome/zarr/pyramid/backend/n5/N5PyramidBackend.java
@@ -31,7 +31,7 @@ package sc.fiji.ome.zarr.pyramid.backend.n5;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import net.imglib2.RandomAccessibleInterval;
@@ -51,9 +51,12 @@ import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5MetadataParser;
-import org.janelia.saalfeldlab.n5.universe.metadata.N5SingleScaleMetadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.SpatialMetadataGroup;
 import org.janelia.saalfeldlab.n5.universe.metadata.axes.Axis;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.NgffSingleScaleAxesMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadataParser;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,11 +103,9 @@ public class N5PyramidBackend<
 	{
 		final N5Reader reader = new N5Factory().openReader( inputUri.toString() );
 		final N5TreeNode treeNode = new N5TreeNode( "" );
-		final N5Metadata metadata = readMetadata( reader, treeNode );
-		final MetadataAdapter adapter = MetadataAdapterFactory.getAdapter( reader, treeNode );
-		final int multiscaleIndex = 0;
-		final Multiscale multiscale = adapter.initMultiscale( metadata, multiscaleIndex );
-		final Omero omero = adapter.initOmeroMetadata();
+		final OmeNgffMetadata metadata = readMetadata( reader, treeNode );
+		final Multiscale multiscale = buildMultiscale( metadata, 0 );
+		final Omero omero = readOmeroMetadata( reader, treeNode );
 		final ResolutionLevel level0 = multiscale.getLevels().get( 0 );
 
 		final SpatialMetadataGroup< ? > spatialMetadata = Cast.unchecked( metadata );
@@ -156,13 +157,10 @@ public class N5PyramidBackend<
 				.build();
 	}
 
-	private N5Metadata readMetadata( final N5Reader reader, final N5TreeNode node )
+	private OmeNgffMetadata readMetadata( final N5Reader reader, final N5TreeNode node )
 	{
-		final List< N5MetadataParser< ? > > parsers =
-				Arrays.asList( new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadataParser(),
-						new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadataParser(),
-						new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05MetadataParser() );
-		N5DatasetDiscoverer.parseMetadataShallow( reader, node, parsers, new ArrayList<>( parsers ) );
+		final List< N5MetadataParser< ? > > parsers = Collections.singletonList( new OmeNgffMetadataParser( reader ) );
+		N5DatasetDiscoverer.parseMetadataShallow( reader, node, parsers, parsers );
 		final N5Metadata n5Metadata = node.getMetadata();
 		if ( n5Metadata == null )
 		{
@@ -170,7 +168,7 @@ public class N5PyramidBackend<
 				throw new MultiImageDatasetException( inputUri.toString() );
 			throw new NotAMultiscaleImageException( inputUri.toString() );
 		}
-		return n5Metadata;
+		return Cast.unchecked( n5Metadata );
 	}
 
 	private static boolean isBioformats2rawLayout( final N5Reader reader )
@@ -185,6 +183,26 @@ public class N5PyramidBackend<
 			logger.debug( "Could not read 'ome' attribute: {}", e.getMessage() );
 			return false;
 		}
+	}
+
+	private static Multiscale buildMultiscale( final OmeNgffMetadata metadata, final int multiscaleIndex )
+	{
+		final OmeNgffMultiScaleMetadata ms = metadata.multiscales[ multiscaleIndex ];
+		final NgffSingleScaleAxesMetadata[] children = ms.getChildrenMetadata();
+		if ( children == null || children.length == 0 || children[ 0 ] == null )
+			throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children attributes." );
+		final List< ResolutionLevel > levels = new ArrayList<>();
+		for ( int i = 0; i < children.length; i++ )
+			levels.add( new ResolutionLevel( children[ i ].getPath(), i, children[ i ].getAttributes(), children[ i ].getAxes(), children[ i ].getScale() ) );
+		return new Multiscale( ms.name, levels, children[ 0 ].getAttributes().getDataType() );
+	}
+
+	private static Omero readOmeroMetadata( final N5Reader reader, final N5TreeNode node )
+	{
+		final JsonElement base = reader.getAttribute( node.getPath(), "", JsonElement.class );
+		final String omeroKey = ( base != null && base.isJsonObject() && base.getAsJsonObject().has( "ome" ) )
+				? "ome/omero" : "omero";
+		return new Gson().fromJson( reader.getAttribute( node.getPath(), omeroKey, JsonElement.class ), Omero.class );
 	}
 
 	private VoxelDimensions createVoxelDimensions( final AffineTransform3D transform, final String unit )
@@ -202,48 +220,28 @@ public class N5PyramidBackend<
 	// Axis configuration
 	// ---------------------------------------------------------------------
 
-	private AxisCalibration[] createAxisCalibrations( final ResolutionLevel level )
+	private static AxisCalibration[] createAxisCalibrations( final ResolutionLevel level )
 	{
-		if ( level.axes != null )
-		{
-			final AxisCalibration[] result = new AxisCalibration[ level.axes.length ];
-			for ( int i = 0; i < level.axes.length; i++ )
-			{
-				final Axis axis = level.axes[ i ];
-				result[ i ] = new AxisCalibration( axis.getName(), axis.getUnit(), level.scales[ i ] );
-			}
-			return result;
-		}
-		if ( level.axisNames != null )
-		{
-			final AxisCalibration[] result = new AxisCalibration[ level.axisNames.length ];
-			for ( int i = 0; i < level.axisNames.length; i++ )
-				result[ i ] = new AxisCalibration( level.axisNames[ i ], level.units[ i ], level.scales[ i ] );
-			return result;
-		}
-		return new AxisCalibration[ 0 ];
+		if ( level.axes == null )
+			return new AxisCalibration[ 0 ];
+		final AxisCalibration[] result = new AxisCalibration[ level.axes.length ];
+		for ( int i = 0; i < level.axes.length; i++ )
+			result[ i ] = new AxisCalibration( level.axes[ i ].getName(), level.axes[ i ].getUnit(), level.scales[ i ] );
+		return result;
 	}
 
-	private int getAxisSize( final ResolutionLevel level, final String axisName )
+	private static int getAxisSize( final ResolutionLevel level, final String axisName )
 	{
 		final int axisIndex = findAxisIndex( level, axisName );
 		return axisIndex >= 0 ? ( int ) level.attributes.getDimensions()[ axisIndex ] : 1;
 	}
 
-	private int findAxisIndex( final ResolutionLevel level, final String axisName )
+	private static int findAxisIndex( final ResolutionLevel level, final String axisName )
 	{
 		if ( level.axes != null )
-		{
 			for ( int i = 0; i < level.axes.length; i++ )
 				if ( axisName.equals( level.axes[ i ].getName() ) )
 					return i;
-		}
-		else if ( level.axisNames != null )
-		{
-			for ( int i = 0; i < level.axisNames.length; i++ )
-				if ( axisName.equals( level.axisNames[ i ] ) )
-					return i;
-		}
 		return -1;
 	}
 
@@ -295,164 +293,18 @@ public class N5PyramidBackend<
 
 		private final DatasetAttributes attributes;
 
-		private final Axis[] axes; // for v04/v05 metadata
-
-		private final String[] axisNames; // for v03 metadata
-
-		private final String[] units; // for v03 metadata
+		private final Axis[] axes;
 
 		private final double[] scales;
 
 		private ResolutionLevel( final String datasetPath, final int index, final DatasetAttributes attributes,
-				final Axis[] axes, final String[] axisNames, final String[] units, final double[] scales )
+				final Axis[] axes, final double[] scales )
 		{
 			this.datasetPath = datasetPath;
 			this.index = index;
 			this.attributes = attributes;
 			this.axes = axes;
-			this.axisNames = axisNames;
-			this.units = units;
 			this.scales = scales;
-		}
-	}
-
-	// ---------------------------------------------------------------------
-	// Metadata adapter strategy (per OME-Zarr version)
-	// ---------------------------------------------------------------------
-
-	private interface MetadataAdapter
-	{
-		Multiscale initMultiscale( N5Metadata metadata, int multiscaleIndex );
-
-		Omero initOmeroMetadata();
-	}
-
-	private abstract static class AbstractMetadataAdapter implements MetadataAdapter
-	{
-		protected final N5Reader reader;
-
-		protected final N5TreeNode node;
-
-		AbstractMetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			this.reader = reader;
-			this.node = node;
-		}
-
-		protected Multiscale buildMultiscale( final String name,
-				final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.NgffSingleScaleAxesMetadata[] children )
-		{
-			final List< ResolutionLevel > levels = new ArrayList<>();
-			int index = 0;
-			for ( final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.NgffSingleScaleAxesMetadata single : children )
-				levels.add( new ResolutionLevel( single.getPath(), index++, single.getAttributes(), single.getAxes(), null, null,
-						single.getScale() ) );
-			return new Multiscale( name, levels, children[ 0 ].getAttributes().getDataType() );
-		}
-
-		@Override
-		public Omero initOmeroMetadata()
-		{
-			final JsonElement base = reader.getAttribute( node.getPath(), getOmeroKey(), JsonElement.class );
-			return new Gson().fromJson( base, Omero.class );
-		}
-
-		protected abstract String getOmeroKey();
-	}
-
-	private static class MetadataAdapterFactory
-	{
-		static MetadataAdapter getAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			final N5Metadata metadata = node.getMetadata();
-			if ( metadata == null )
-				throw new NotAMultiscaleImageException( reader.getURI().toString() );
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata )
-				return new V05MetadataAdapter( reader, node );
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata )
-				return new V04MetadataAdapter( reader, node );
-			if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata )
-				return new V03MetadataAdapter( reader, node );
-			throw new NotAMultiscaleImageException( reader.getURI().toString() );
-		}
-	}
-
-	private static class V05MetadataAdapter extends AbstractMetadataAdapter
-	{
-		V05MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata omeNgffMetadata =
-					Cast.unchecked( n5Metadata );
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata multiscales =
-					omeNgffMetadata.multiscales[ multiscaleIndex ];
-			return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "ome/omero";
-		}
-	}
-
-	private static class V04MetadataAdapter extends AbstractMetadataAdapter
-	{
-		V04MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata multiscales =
-					omeNgffMetadata.multiscales[ multiscaleIndex ];
-			if ( multiscales.getChildrenMetadata().length == 0 || multiscales.getChildrenMetadata()[ 0 ] == null )
-				throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children attributes." );
-			return buildMultiscale( multiscales.name, multiscales.getChildrenMetadata() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "omero";
-		}
-	}
-
-	private static class V03MetadataAdapter extends AbstractMetadataAdapter
-	{
-		V03MetadataAdapter( final N5Reader reader, final N5TreeNode node )
-		{
-			super( reader, node );
-		}
-
-		@Override
-		public Multiscale initMultiscale( final N5Metadata n5Metadata, final int multiscaleIndex )
-		{
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata omeNgffMetadata = Cast.unchecked( n5Metadata );
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMultiScaleMetadata multiscales =
-					omeNgffMetadata.getMultiscales()[ multiscaleIndex ];
-			if ( multiscales.getChildrenMetadata() == null || multiscales.getChildrenMetadata().length == 0 )
-				throw new NotAMultiscaleImageException( "Multiscale metadata does not contain any children metadata." );
-			final List< ResolutionLevel > levels = new ArrayList<>();
-			int index = 0;
-			for ( final N5SingleScaleMetadata single : multiscales.getChildrenMetadata() )
-				levels.add( new ResolutionLevel( single.getPath(), index++, single.getAttributes(), null, multiscales.axes,
-						multiscales.units(), single.getPixelResolution() ) );
-			return new Multiscale( multiscales.name, levels, multiscales.getChildrenMetadata()[ 0 ].getAttributes().getDataType() );
-		}
-
-		@Override
-		protected String getOmeroKey()
-		{
-			return "omero";
 		}
 	}
 }

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/backend/BackendBenchmark.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/backend/BackendBenchmark.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -37,6 +37,8 @@ import dev.zarr.zarrjava.store.FilesystemStore;
 import dev.zarr.zarrjava.store.StoreHandle;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
+
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadataParser;
 import org.scijava.Context;
 import org.slf4j.LoggerFactory;
 import org.janelia.saalfeldlab.n5.N5Reader;
@@ -46,8 +48,7 @@ import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.N5TreeNode;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5MetadataParser;
-import org.janelia.saalfeldlab.n5.universe.metadata.N5SingleScaleMetadata;
-import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05Metadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadata;
 
 import sc.fiji.ome.zarr.pyramid.Pyramidal5DImageDataImpl;
 import sc.fiji.ome.zarr.pyramid.backend.zarrjava.ZarrJavaPyramidBackend;
@@ -60,6 +61,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.logging.Handler;
@@ -190,10 +192,7 @@ public class BackendBenchmark
 			throw new IOException( "No zarr root for " + inputPath );
 		final N5Reader reader = new N5Factory().openReader( inputPath.toUri().toString() );
 		final N5TreeNode node = new N5TreeNode( "" );
-		final List< N5MetadataParser< ? > > parsers = Arrays.asList(
-				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadataParser(),
-				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadataParser(),
-				new org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v05.OmeNgffV05MetadataParser() );
+		final List< N5MetadataParser< ? > > parsers = Collections.singletonList( new OmeNgffMetadataParser( reader ) );
 		N5DatasetDiscoverer.parseMetadataShallow( reader, node, parsers, parsers );
 		final N5Metadata metadata = node.getMetadata();
 		if ( metadata == null )
@@ -204,24 +203,8 @@ public class BackendBenchmark
 	private static String resolveN5Level0Path( final N5OpenContext ctx ) throws IOException
 	{
 		final N5Metadata metadata = ctx.metadata;
-		if ( metadata instanceof OmeNgffV05Metadata )
-		{
-			final OmeNgffV05Metadata v05 = ( OmeNgffV05Metadata ) metadata;
-			return v05.multiscales[ 0 ].getChildrenMetadata()[ 0 ].getPath();
-		}
-		if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata )
-		{
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata v04 =
-					( org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata ) metadata;
-			return v04.multiscales[ 0 ].getChildrenMetadata()[ 0 ].getPath();
-		}
-		if ( metadata instanceof org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata )
-		{
-			final org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata v03 =
-					( org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v03.OmeNgffMetadata ) metadata;
-			final N5SingleScaleMetadata[] children = v03.getMultiscales()[ 0 ].getChildrenMetadata();
-			return children[ 0 ].getPath();
-		}
+		if ( metadata instanceof OmeNgffMetadata )
+			return ( ( OmeNgffMetadata ) metadata ).multiscales[ 0 ].getChildrenMetadata()[ 0 ].getPath();
 		throw new IOException( "Unsupported metadata class: " + metadata.getClass().getName() );
 	}
 

--- a/src/test/java/sc/fiji/ome/zarr/pyramid/demo/N5ReaderDemo.java
+++ b/src/test/java/sc/fiji/ome/zarr/pyramid/demo/N5ReaderDemo.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -32,8 +32,8 @@ import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.universe.N5DatasetDiscoverer;
 import org.janelia.saalfeldlab.n5.universe.N5Factory;
 import org.janelia.saalfeldlab.n5.universe.metadata.N5Metadata;
-import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMetadata;
-import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.v04.OmeNgffMultiScaleMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMetadata;
+import org.janelia.saalfeldlab.n5.universe.metadata.ome.ngff.OmeNgffMultiScaleMetadata;
 
 @SuppressWarnings( "all" )
 public class N5ReaderDemo
@@ -50,27 +50,15 @@ public class N5ReaderDemo
 
 		if ( m instanceof OmeNgffMetadata )
 		{
-			OmeNgffMetadata mv04 = ( OmeNgffMetadata ) m;
-			System.out.println( "name: " + mv04.getName() );
-			for ( OmeNgffMultiScaleMetadata ms : mv04.multiscales )
+			OmeNgffMetadata metadata = ( OmeNgffMetadata ) m;
+			System.out.println( "name: " + metadata.getName() );
+			for ( OmeNgffMultiScaleMetadata ms : metadata.multiscales )
 			{
 				System.out.println( "----------------" );
 				System.out.println( "name: " + ms.name + "     type: " + ms.type + "     version: " + ms.version );
 				System.out.println( ms.coordinateTransformations );
 			}
 		}
-
-		/*
-		if (m instanceof OmeNgffV05Metadata) {
-			OmeNgffV05Metadata mv05 = (OmeNgffV05Metadata)m;
-			System.out.println("name: "+mv05.getName());
-			for (OmeNgffMultiScaleMetadata ms : mv05.multiscales) {
-				System.out.println("----------------");
-				System.out.println("name: "+ms.name+"     type: "+ms.type+"     version: "+ms.version);
-				System.out.println(ms.coordinateTransformations);
-			}
-		}
-		*/
 
 		//TODO fetch v0.5 NGFF Metadata -> ask John
 		//there was supposed to be some class for it


### PR DESCRIPTION
This pull request modernizes and simplifies OME-Zarr metadata handling, updates dependencies, and clarifies documentation regarding version support. The most important changes include refactoring the `N5PyramidBackend` to use a unified metadata parser, updating the Maven dependencies, and improving documentation to accurately describe backend and version compatibility.

**Dependency updates:**

* Updated all N5-related Maven dependencies in `pom.xml` from alpha/pre-release versions to their latest stable releases.

```
		<n5.version>4.0.0</n5.version>
		<n5-aws-s3.version>5.0.0</n5-aws-s3.version>
		<n5-blosc.version>2.0.0</n5-blosc.version>
		<n5-google-cloud.version>6.0.0</n5-google-cloud.version>
		<n5-hdf5>3.0.0</n5-hdf5>
		<n5-ij.version>5.0.0</n5-ij.version>
		<n5-imglib2.version>8.0.0</n5-imglib2.version>
		<n5-universe.version>3.0.0</n5-universe.version>
		<n5-viewer_fiji.version>6.2.0</n5-viewer_fiji.version>
		<n5-zarr.version>2.0.0</n5-zarr.version>
		<n5-zstandard.version>2.0.0</n5-zstandard.version>
```

**Core backend and metadata handling improvements:**

* Refactored `N5PyramidBackend` to use the unified `OmeNgffMetadataParser` for all OME-Zarr versions, removing the adapter strategy and simplifying code for reading metadata and building multiscale structures

**Documentation / version support:**

* Clarified in `README.md` that OME-Zarr v0.3 is now supported (in addition to v0.4 and v0.5), but only with the N5 backend; the Zarr-java backend supports only v0.4 and v0.5.

