### PR TITLE
Add support for opening OME-Zarr datasets in public S3 stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If the dropped / pasted target is not recognized as a **OME-Zarr v0.3 - v0.5** r
 
 # Features
 
-## Drag & Drop of local OME-Zarr folders and Copy & Paste of OME-Zarr URIs (local folder, http, https)
+## Drag & Drop of local OME-Zarr folders and Copy & Paste of OME-Zarr URIs (local folder, http, https, s3)
 
 There are several options for what Fiji can do after drag & drop / copy & paste:
 
@@ -37,7 +37,12 @@ and easily handles even the huge ones.
 
 ### Copy & Paste:
 
-* Supports local paths and http(s) URLs (s3 is planned)
+* Supports local paths, http(s) URLs, and `s3://` URIs
+    * Public (anonymous) S3 buckets work out of the box, e.g.
+      `s3://janelia-cosem-datasets/jrc_mus-choroid-plexus-3/jrc_mus-choroid-plexus-3.zarr/recon-1/em/fibsem-uint8`.
+    * Private buckets use your ambient AWS credentials (environment variables, `~/.aws/credentials`,
+      instance profile, etc.); if those are absent, access falls back to anonymous.
+    * The AWS region defaults to `us-east-1`.
 * Three entry points:
     * Paste with `CTRL` / `CMD` / `SHIFT` + `V` (requires FIJI latest)
     * Paste via menu: Plugins -> OME-Zarr -> Paste OME-Zarr URI

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/open/PasteToOpenAction.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/open/PasteToOpenAction.java
@@ -66,7 +66,11 @@ public class PasteToOpenAction
 		final URI uri = ClipboardUtils.readClipboardAsUri( errorHandler );
 		if ( uri == null )
 			return false;
-		if ( !ZarrUtils.isZarr( uri ) )
+		// For s3:// URIs the probe would require its own short-lived S3Client purely
+		// for detection.
+		// It is skipped because the actual open method creates the client it needs anyway
+		// and reports and error if the location turns out not to be OME-Zarr.
+		if ( !"s3".equalsIgnoreCase( uri.getScheme() ) && !ZarrUtils.isZarr( uri ) )
 		{
 			if ( errorHandler != null )
 				errorHandler.accept( "The pasted location does not appear to be an OME-Zarr dataset:\n" + uri + "." );

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/open/ZarrOpenActions.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/open/ZarrOpenActions.java
@@ -41,15 +41,12 @@ import java.net.URI;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
-import net.imglib2.img.Img;
 
 import ij.IJ;
 import ome.zarr.fijiui.open.options.ZarrOpenBehavior;
 import ome.zarr.fijiui.open.options.ZarrOpeningSettings;
 import ome.zarr.fijiui.open.options.ZarrReaderBackend;
-import ome.zarr.fiji.PyramidalDataset;
 import ome.zarr.fiji.open.ZarrOpener;
 import ome.zarr.fijiui.dialog.DnDActionChooser;
 import ome.zarr.fijiui.util.ScriptUtils;
@@ -238,11 +235,6 @@ public class ZarrOpenActions
 		return opener.openBDVWithImage();
 	}
 
-	Object openImage( final Function< PyramidalDataset, Object > multiScaleImageOpener,
-			final Function< Img< ? >, Object > singleScaleImageOpener )
-	{
-		return opener.openImage( multiScaleImageOpener, singleScaleImageOpener );
-	}
 
 	/**
 	 * Opens the Fiji script editor pre-filled with a scriptlet that opens the

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
@@ -36,6 +36,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
@@ -136,7 +137,7 @@ public final class ClipboardUtils
 		{
 			parsed = new URI( text );
 		}
-		catch ( Exception e )
+		catch ( URISyntaxException e )
 		{
 			logger.debug( "Text is not valid URI syntax, will try as a local path: {}", e.getMessage() );
 		}

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
@@ -84,6 +84,7 @@ public final class ClipboardUtils
 	 * Handles three input forms:
 	 * <ul>
 	 *   <li>{@code http://} or {@code https://} URLs &ndash; used as-is</li>
+	 *   <li>{@code s3://} URIs &ndash; used as-is</li>
 	 *   <li>{@code file:} URIs &ndash; used as-is</li>
 	 *   <li>plain filesystem paths &ndash; converted with
 	 *       {@link Paths#get(String, String...)}{@code .toUri()}</li>
@@ -99,9 +100,10 @@ public final class ClipboardUtils
 
 	/**
 	 * Converts a string to a {@link URI} suitable for opening an OME-Zarr dataset.
-	 * Handles three input forms:
+	 * Handles four input forms:
 	 * <ul>
 	 *   <li>{@code http://} or {@code https://} URLs &ndash; used as-is</li>
+	 *   <li>{@code s3://} URIs &ndash; used as-is</li>
 	 *   <li>{@code file:} URIs &ndash; used as-is</li>
 	 *   <li>plain filesystem paths &ndash; converted with
 	 *       {@link Paths#get(String, String...)}{@code .toUri()}</li>
@@ -137,12 +139,13 @@ public final class ClipboardUtils
 		if ( parsed != null )
 		{
 			final String scheme = parsed.getScheme();
-			if ( "http".equalsIgnoreCase( scheme ) || "https".equalsIgnoreCase( scheme ) || "file".equalsIgnoreCase( scheme ) )
+			if ( "http".equalsIgnoreCase( scheme ) || "https".equalsIgnoreCase( scheme )
+					|| "file".equalsIgnoreCase( scheme ) || "s3".equalsIgnoreCase( scheme ) )
 				return parsed;
 			if ( scheme != null )
 			{
 				errorHandler.accept( "Unsupported URL scheme '" + scheme + "':\n" + text + "\n\n"
-						+ "Supported schemes are http, https, and file." );
+						+ "Supported schemes are http, https, file, and s3." );
 				return null;
 			}
 		}

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
@@ -81,11 +81,14 @@ public final class ClipboardUtils
 
 	/**
 	 * Resolve text read from clipboard to a URI suitable for opening an OME-Zarr dataset.
-	 * Handles three input forms:
+	 * Handles four input forms:
 	 * <ul>
 	 *   <li>{@code http://} or {@code https://} URLs &ndash; used as-is</li>
 	 *   <li>{@code s3://} URIs &ndash; used as-is</li>
-	 *   <li>{@code file:} URIs &ndash; used as-is</li>
+	 *   <li>{@code file:} URIs &ndash; used as-is; both {@code file:/path/to/data.zarr} and
+	 *       {@code file:///path/to/data.zarr} are usable. A URI naming a host
+	 *       ({@code file://some-server/path/to/data.zarr}) is rejected by the backends,
+	 *       because {@link Paths#get(URI)} accepts no authority component.</li>
 	 *   <li>plain filesystem paths &ndash; converted with
 	 *       {@link Paths#get(String, String...)}{@code .toUri()}</li>
 	 * </ul>
@@ -104,7 +107,10 @@ public final class ClipboardUtils
 	 * <ul>
 	 *   <li>{@code http://} or {@code https://} URLs &ndash; used as-is</li>
 	 *   <li>{@code s3://} URIs &ndash; used as-is</li>
-	 *   <li>{@code file:} URIs &ndash; used as-is</li>
+	 *   <li>{@code file:} URIs &ndash; used as-is; both {@code file:/path/to/data.zarr} and
+	 *       {@code file:///path/to/data.zarr} are usable. A URI naming a host
+	 *       ({@code file://some-server/path/to/data.zarr}) is rejected by the backends,
+	 *       because {@link Paths#get(URI)} accepts no authority component.</li>
 	 *   <li>plain filesystem paths &ndash; converted with
 	 *       {@link Paths#get(String, String...)}{@code .toUri()}</li>
 	 * </ul>

--- a/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
+++ b/ome-zarr-fiji-ui/src/main/java/ome/zarr/fijiui/util/ClipboardUtils.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -146,6 +146,12 @@ public final class ClipboardUtils
 		if ( parsed != null )
 		{
 			final String scheme = parsed.getScheme();
+			if ( "file".equalsIgnoreCase( scheme ) && parsed.getAuthority() != null )
+			{
+				errorHandler.accept( "A 'file:' URL cannot name a host:\n" + text + "\n\n"
+						+ "Use file:///path/to/data.zarr (three slashes) for a local path." );
+				return null;
+			}
 			if ( "http".equalsIgnoreCase( scheme ) || "https".equalsIgnoreCase( scheme )
 					|| "file".equalsIgnoreCase( scheme ) || "s3".equalsIgnoreCase( scheme ) )
 				return parsed;

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static ome.zarr.ZarrTestUtils.IMAGE_NAME;
 
 import net.imagej.Dataset;
@@ -95,8 +96,10 @@ import javax.swing.SwingUtilities;
 import bdv.viewer.ViewerFrame;
 import bdv.util.BdvStackSource;
 import ij.ImagePlus;
+import dev.zarr.zarrjava.store.StoreException;
 import ome.zarr.fijiui.settings.UserScriptSettings;
 import ome.zarr.fiji.Pyramidal;
+import ome.zarr.zarrjava.ZarrJavaPyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
 import ome.zarr.fiji.PyramidalBdv;
 import ome.zarr.fiji.PyramidalDataset;
@@ -680,6 +683,43 @@ class ZarrOpenActionsTest
 			assertNull( error.get(), "Error handler called for backend " + backend + ": " + error.get() );
 			assertEquals( 1, multiScaleCounter.get() );
 			assertEquals( 0, singleScaleCounter.get() );
+		}
+	}
+
+	@ParameterizedTest
+	@MethodSource( "readerBackends" )
+	@SuppressWarnings( "rawtypes" )
+	void storeAccessErrorIsReportedToErrorHandler( final ZarrReaderBackend backend )
+	{
+		try ( Context context = new Context() )
+		{
+			final URI uri = URI.create( "s3://nonexistent-bucket/some/path" );
+			final AtomicReference< String > capturedError = new AtomicReference<>();
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings();
+			settings.setReaderBackend( backend );
+
+			if ( backend == ZarrReaderBackend.ZARR_JAVA )
+			{
+				try ( MockedConstruction< ZarrJavaPyramidBackend > mock = mockConstruction(
+						ZarrJavaPyramidBackend.class,
+						( mockBackend, ctx ) -> when( mockBackend.load( any() ) )
+								.thenThrow( new StoreException( "Access Denied (403)" ) ) ) )
+				{
+					final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
+					assertDoesNotThrow( () -> actions.openImage( dataset -> null, img -> null ) );
+					assertEquals( 1, mock.constructed().size(), "Expected exactly one ZarrJavaPyramidBackend to be constructed" );
+				}
+			}
+			else
+			{
+				// N5 backend throws N5Exception.N5IOException immediately (local failure, no network needed)
+				final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
+				assertDoesNotThrow( () -> actions.openImage( dataset -> null, img -> null ) );
+			}
+
+			assertNotNull( capturedError.get(), "Error handler should have been called for backend " + backend );
+			assertTrue( capturedError.get().contains( uri.toString() ),
+					"Error message should contain the URI for backend " + backend + ", got: " + capturedError.get() );
 		}
 	}
 

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
@@ -659,6 +659,30 @@ class ZarrOpenActionsTest
 		}
 	}
 
+	// --- S3 integration tests (require network access) ---
+
+	static final URI S3_JANELIA_CHOROID_PLEXUS =
+			URI.create( "s3://janelia-cosem-datasets/jrc_mus-choroid-plexus-3/jrc_mus-choroid-plexus-3.zarr/recon-1/em/fibsem-uint8" );
+
+	@ParameterizedTest
+	@MethodSource( "readerBackends" )
+	void openImageFromS3( final ZarrReaderBackend backend )
+	{
+		try (Context context = new Context())
+		{
+			final AtomicReference< String > error = new AtomicReference<>();
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings();
+			settings.setReaderBackend( backend );
+			final ZarrOpenActions actions = new ZarrOpenActions( S3_JANELIA_CHOROID_PLEXUS, context, settings, error::set );
+			final AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
+			final AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
+			actions.openImage( dataset -> multiScaleCounter.incrementAndGet(), img -> singleScaleCounter.incrementAndGet() );
+			assertNull( error.get(), "Error handler called for backend " + backend + ": " + error.get() );
+			assertEquals( 1, multiScaleCounter.get() );
+			assertEquals( 0, singleScaleCounter.get() );
+		}
+	}
+
 	@Test
 	void testRunScriptWithNoScriptSpecified() throws URISyntaxException, InterruptedException, InvocationTargetException
 	{

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static ome.zarr.ZarrTestUtils.IMAGE_NAME;
 
 import net.imagej.Dataset;
@@ -95,8 +94,6 @@ import bdv.util.BdvStackSource;
 import ij.ImagePlus;
 import ome.zarr.fijiui.settings.UserScriptSettings;
 import ome.zarr.fiji.Pyramidal;
-import ome.zarr.zarrjava.ZarrJavaPyramidBackend;
-import ome.zarr.imglib2.exceptions.StoreAccessException;
 import ome.zarr.imglib2.PyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
 import ome.zarr.fiji.open.ZarrOpener;
@@ -685,29 +682,10 @@ class ZarrOpenActionsTest
 			final ZarrOpeningSettings settings = new ZarrOpeningSettings();
 			settings.setReaderBackend( backend );
 
-			if ( backend == ZarrReaderBackend.ZARR_JAVA )
-			{
-				try (MockedConstruction< ZarrJavaPyramidBackend > mock = mockConstruction(
-						ZarrJavaPyramidBackend.class,
-						( mockBackend, ctx ) -> when( mockBackend.load( any() ) )
-								.thenThrow( new StoreAccessException( uri.toString(),
-										new RuntimeException( "Access Denied (403)" ) ) ) ))
-				{
-					final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
-					assertDoesNotThrow( () -> {
-						actions.openIJWithImage();
-					} );
-					assertEquals( 1, mock.constructed().size(), "Expected exactly one ZarrJavaPyramidBackend to be constructed" );
-				}
-			}
-			else
-			{
-				// N5 backend throws N5Exception.N5IOException immediately (local failure, no network needed)
-				final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
-				assertDoesNotThrow( () -> {
-					actions.openIJWithImage();
-				} );
-			}
+			final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
+			assertDoesNotThrow( () -> {
+				actions.openIJWithImage();
+			}, "Store access failures must not escape openIJWithImage() for backend " + backend );
 
 			assertNotNull( capturedError.get(), "Error handler should have been called for backend " + backend );
 			assertTrue( capturedError.get().contains( uri.toString() ),

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -78,10 +77,8 @@ import com.sun.net.httpserver.HttpServer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import bdv.tools.brightness.ConverterSetup;
@@ -100,7 +97,9 @@ import ome.zarr.fijiui.settings.UserScriptSettings;
 import ome.zarr.fiji.Pyramidal;
 import ome.zarr.zarrjava.ZarrJavaPyramidBackend;
 import ome.zarr.imglib2.exceptions.StoreAccessException;
+import ome.zarr.imglib2.PyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
+import ome.zarr.fiji.open.ZarrOpener;
 import ome.zarr.fiji.PyramidalBdv;
 import ome.zarr.fiji.PyramidalDataset;
 import ome.zarr.fijiui.open.options.ZarrOpeningSettings;
@@ -113,9 +112,26 @@ import ome.zarr.ZarrTestUtils;
 
 class ZarrOpenActionsTest
 {
+
 	static Stream< ZarrReaderBackend > readerBackends()
 	{
 		return Stream.of( ZarrReaderBackend.N5, ZarrReaderBackend.ZARR_JAVA );
+	}
+
+	/**
+	 * Loads the dataset headlessly through {@link ZarrOpener#getContents()} with
+	 * the given backend, without instantiating any UI. Returns the loaded
+	 * {@link PyramidContents}; throws the relevant domain exception (e.g.
+	 * {@link ome.zarr.imglib2.exceptions.NotAMultiscaleImageException} or
+	 * {@link ome.zarr.imglib2.exceptions.MultiImageDatasetException}).
+	 * Lets tests assert that a dataset opens as a multiscale image without showing a window.
+	 */
+	private static PyramidContents< ? > loadMultiscaleHeadless( final URI uri, final Context context,
+			final ZarrReaderBackend backend )
+	{
+		final PyramidBackend pyramidBackend = backend.createBackend();
+		final ZarrOpener opener = new ZarrOpener( uri, context, pyramidBackend, null, error -> {} );
+		return opener.getContents();
 	}
 
 	static Stream< String > omeZarrExamples()
@@ -290,18 +306,13 @@ class ZarrOpenActionsTest
 		Path path = ZarrTestUtils.resourcePath( resource );
 		try (Context context = new Context())
 		{
-			ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context );
-			AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
-			AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-			Function< PyramidalDataset, Object > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
-			Function< Img< ? >, Object > singleScaleOpeningCounter = img -> singleScaleCounter.incrementAndGet();
-			actions.openImage( multiScaleOpeningCounter, singleScaleOpeningCounter );
-			assertEquals( 1, multiScaleCounter.get() );
-			assertEquals( 0, singleScaleCounter.get() );
+			assertNotNull( loadMultiscaleHeadless( path.toUri(), context, ZarrOpeningSettings.DEFAULT_READER_BACKEND ),
+					"Expected " + resource + " to open as a multiscale image" );
 		}
 	}
 
 	@Test
+	@SuppressWarnings( "java:S1612" )
 	void testOpenValidSingleScaleImagePath() throws URISyntaxException
 	{
 		String[] validPaths = {
@@ -313,19 +324,19 @@ class ZarrOpenActionsTest
 			for ( String invalidPath : validPaths )
 			{
 				Path path = ZarrTestUtils.resourcePath( invalidPath );
-				ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, null, System.out::println );
-				AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
-				AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-				Function< PyramidalDataset, Object > multiScaleOpeningCounter = dataset -> multiScaleCounter.incrementAndGet();
-				Function< Img< ? >, Object > singleScaleOpeningCounter = img -> singleScaleCounter.incrementAndGet();
-				actions.openImage( multiScaleOpeningCounter, singleScaleOpeningCounter );
-				assertEquals( 0, multiScaleCounter.get() );
-				assertEquals( 0, singleScaleCounter.get() ); // currently not supported
+				AtomicReference< String > capturedError = new AtomicReference<>();
+				ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, null, capturedError::set );
+				assertDoesNotThrow( () -> {
+					actions.openIJWithImage();
+				} );
+				assertNotNull( capturedError.get(),
+						"Single-scale path " + invalidPath + " should be reported as not (yet) supported" );
 			}
 		}
 	}
 
 	@Test
+	@SuppressWarnings( "java:S1612" )
 	void testOpenInvalidImagePaths() throws URISyntaxException
 	{
 		String[] invalidPaths = {
@@ -338,15 +349,16 @@ class ZarrOpenActionsTest
 			{
 				Path path = ZarrTestUtils.resourcePath( invalidPath );
 				ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, null, System.out::println );
-				Function< PyramidalDataset, Object > multiScaleNoOp = pyramidalDataset -> null;
-				Function< Img< ? >, Object > singleScaleNoOp = img -> null;
-				assertDoesNotThrow( () -> actions.openImage( multiScaleNoOp, singleScaleNoOp ) );
+				assertDoesNotThrow( () -> {
+					actions.openIJWithImage();
+				} );
 			}
 		}
 	}
 
 	@ParameterizedTest
 	@MethodSource( "readerBackends" )
+	@SuppressWarnings( "java:S1612" )
 	void testOpenBioformats2rawCollectionRootReportsMultiImage( ZarrReaderBackend backend ) throws URISyntaxException
 	{
 		Path path = ZarrTestUtils.resourcePath( "ome/zarr/testdata/bioformats2raw_testing/bf2raw_dataset_v5.ome.zarr" );
@@ -357,13 +369,9 @@ class ZarrOpenActionsTest
 			ZarrOpeningSettings settings = new ZarrOpeningSettings();
 			settings.setReaderBackend( backend );
 			ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, settings, errorHandler );
-			AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
-			AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-			Function< PyramidalDataset, Object > multiScaleOpener = dataset -> multiScaleCounter.incrementAndGet();
-			Function< Img< ? >, Object > singleScaleOpener = img -> singleScaleCounter.incrementAndGet();
-			assertDoesNotThrow( () -> actions.openImage( multiScaleOpener, singleScaleOpener ) );
-			assertEquals( 0, multiScaleCounter.get(), "Multi-image collection must not be opened as a single multiscale image" );
-			assertEquals( 0, singleScaleCounter.get() );
+			assertDoesNotThrow( () -> {
+				actions.openIJWithImage();
+			} );
 			assertNotNull( capturedError.get(), "Error handler should have been called for backend " + backend );
 			assertTrue( capturedError.get().contains( "multiple images" ),
 					"Expected multi-image message from backend, got: " + capturedError.get() );
@@ -383,27 +391,14 @@ class ZarrOpenActionsTest
 			for ( String childPath : childPaths )
 			{
 				Path path = ZarrTestUtils.resourcePath( childPath );
-				AtomicReference< String > capturedError = new AtomicReference<>();
-				Consumer< String > errorHandler = capturedError::set;
-				ZarrOpeningSettings settings = new ZarrOpeningSettings();
-				settings.setReaderBackend( backend );
-				ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, settings, errorHandler );
-				AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
-				AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-				Function< PyramidalDataset, Object > multiScaleOpener = dataset -> multiScaleCounter.incrementAndGet();
-				Function< Img< ? >, Object > singleScaleOpener = img -> singleScaleCounter.incrementAndGet();
-				assertDoesNotThrow( () -> actions.openImage( multiScaleOpener, singleScaleOpener ),
-						"Opening child image " + childPath + " should not throw" );
-				assertEquals( 1, multiScaleCounter.get(),
-						"Child image " + childPath + " should be opened as a multiscale image" );
-				assertEquals( 0, singleScaleCounter.get() );
-				assertNull( capturedError.get(),
-						"Error handler should not have been called for child " + childPath + ", got: " + capturedError.get() );
+				assertNotNull( loadMultiscaleHeadless( path.toUri(), context, backend ),
+						"Child image " + childPath + " should open as a multiscale image" );
 			}
 		}
 	}
 
 	@Test
+	@SuppressWarnings( "java:S1612" )
 	void testOpenNonMatchingResolution() throws URISyntaxException
 	{
 		try (Context context = new Context())
@@ -411,9 +406,9 @@ class ZarrOpenActionsTest
 			Path path = ZarrTestUtils.resourcePath( "ome/zarr/testdata/5d_testing/5d_dataset_v4.ome.zarr" );
 			ZarrOpeningSettings settings = new ZarrOpeningSettings( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION, 10 );
 			ZarrOpenActions actions = new ZarrOpenActions( path.toUri(), context, settings, System.out::println );
-			Function< PyramidalDataset, Object > multiScaleNoOp = pyramidalDataset -> null;
-			Function< Img< ? >, Object > singleScaleNoOp = img -> null;
-			assertDoesNotThrow( () -> actions.openImage( multiScaleNoOp, singleScaleNoOp ) );
+			assertDoesNotThrow( () -> {
+				actions.openIJWithImage();
+			} );
 		}
 	}
 
@@ -673,25 +668,17 @@ class ZarrOpenActionsTest
 	{
 		try (Context context = new Context())
 		{
-			final AtomicReference< String > error = new AtomicReference<>();
-			final ZarrOpeningSettings settings = new ZarrOpeningSettings();
-			settings.setReaderBackend( backend );
-			final ZarrOpenActions actions = new ZarrOpenActions( S3_JANELIA_CHOROID_PLEXUS, context, settings, error::set );
-			final AtomicInteger multiScaleCounter = new AtomicInteger( 0 );
-			final AtomicInteger singleScaleCounter = new AtomicInteger( 0 );
-			actions.openImage( dataset -> multiScaleCounter.incrementAndGet(), img -> singleScaleCounter.incrementAndGet() );
-			assertNull( error.get(), "Error handler called for backend " + backend + ": " + error.get() );
-			assertEquals( 1, multiScaleCounter.get() );
-			assertEquals( 0, singleScaleCounter.get() );
+			final PyramidContents< ? > contents = loadMultiscaleHeadless( S3_JANELIA_CHOROID_PLEXUS, context, backend );
+			assertNotNull( contents, "Expected the S3 dataset to open as a multiscale image for backend " + backend );
 		}
 	}
 
 	@ParameterizedTest
 	@MethodSource( "readerBackends" )
-	@SuppressWarnings( "rawtypes" )
+	@SuppressWarnings( "java:S1612" )
 	void storeAccessErrorIsReportedToErrorHandler( final ZarrReaderBackend backend )
 	{
-		try ( Context context = new Context() )
+		try (Context context = new Context())
 		{
 			final URI uri = URI.create( "s3://nonexistent-bucket/some/path" );
 			final AtomicReference< String > capturedError = new AtomicReference<>();
@@ -700,14 +687,16 @@ class ZarrOpenActionsTest
 
 			if ( backend == ZarrReaderBackend.ZARR_JAVA )
 			{
-				try ( MockedConstruction< ZarrJavaPyramidBackend > mock = mockConstruction(
+				try (MockedConstruction< ZarrJavaPyramidBackend > mock = mockConstruction(
 						ZarrJavaPyramidBackend.class,
 						( mockBackend, ctx ) -> when( mockBackend.load( any() ) )
 								.thenThrow( new StoreAccessException( uri.toString(),
-										new RuntimeException( "Access Denied (403)" ) ) ) ) )
+										new RuntimeException( "Access Denied (403)" ) ) ) ))
 				{
 					final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
-					assertDoesNotThrow( () -> actions.openImage( dataset -> null, img -> null ) );
+					assertDoesNotThrow( () -> {
+						actions.openIJWithImage();
+					} );
 					assertEquals( 1, mock.constructed().size(), "Expected exactly one ZarrJavaPyramidBackend to be constructed" );
 				}
 			}
@@ -715,7 +704,9 @@ class ZarrOpenActionsTest
 			{
 				// N5 backend throws N5Exception.N5IOException immediately (local failure, no network needed)
 				final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
-				assertDoesNotThrow( () -> actions.openImage( dataset -> null, img -> null ) );
+				assertDoesNotThrow( () -> {
+					actions.openIJWithImage();
+				} );
 			}
 
 			assertNotNull( capturedError.get(), "Error handler should have been called for backend " + backend );

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ZarrOpenActionsTest.java
@@ -96,10 +96,10 @@ import javax.swing.SwingUtilities;
 import bdv.viewer.ViewerFrame;
 import bdv.util.BdvStackSource;
 import ij.ImagePlus;
-import dev.zarr.zarrjava.store.StoreException;
 import ome.zarr.fijiui.settings.UserScriptSettings;
 import ome.zarr.fiji.Pyramidal;
 import ome.zarr.zarrjava.ZarrJavaPyramidBackend;
+import ome.zarr.imglib2.exceptions.StoreAccessException;
 import ome.zarr.imglib2.PyramidContents;
 import ome.zarr.fiji.PyramidalBdv;
 import ome.zarr.fiji.PyramidalDataset;
@@ -703,7 +703,8 @@ class ZarrOpenActionsTest
 				try ( MockedConstruction< ZarrJavaPyramidBackend > mock = mockConstruction(
 						ZarrJavaPyramidBackend.class,
 						( mockBackend, ctx ) -> when( mockBackend.load( any() ) )
-								.thenThrow( new StoreException( "Access Denied (403)" ) ) ) )
+								.thenThrow( new StoreAccessException( uri.toString(),
+										new RuntimeException( "Access Denied (403)" ) ) ) ) )
 				{
 					final ZarrOpenActions actions = new ZarrOpenActions( uri, context, settings, capturedError::set );
 					assertDoesNotThrow( () -> actions.openImage( dataset -> null, img -> null ) );

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/plugin/OpenResolutionLevelCommandTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/plugin/OpenResolutionLevelCommandTest.java
@@ -241,26 +241,8 @@ class OpenResolutionLevelCommandTest
 	private static void runCommand( final Context context, final Map< String, Object > inputs )
 			throws ExecutionException, InterruptedException
 	{
-		// A dataset opened in ImageJ becomes the active pyramidal only via the
-		// asynchronous AWT "activeWindow" event that PyramidalService listens for.
-		// Flush the event queue so that event is processed and the active pyramidal
-		// is resolved before the command's preprocessor injects it; otherwise the
-		// command cancels for lack of an active dataset (flaky under test load).
-		flushEventQueue();
 		CommandInfo info = context.getService( CommandService.class ).getCommand( OpenResolutionLevelCommand.class );
 		context.getService( ModuleService.class ).run( info, true, inputs ).get();
-	}
-
-	private static void flushEventQueue() throws InterruptedException
-	{
-		try
-		{
-			SwingUtilities.invokeAndWait( () -> {} );
-		}
-		catch ( InvocationTargetException e )
-		{
-			throw new IllegalStateException( e );
-		}
 	}
 
 	private static void closeWindows()

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/util/ClipboardUtilsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/util/ClipboardUtilsTest.java
@@ -112,6 +112,15 @@ class ClipboardUtilsTest
 	}
 
 	@Test
+	void s3UriIsAccepted()
+	{
+		final URI result = ClipboardUtils.stringToUri( "s3://my-bucket/path/to/dataset", errorHandler );
+		assertNotNull( result );
+		assertEquals( URI.create( "s3://my-bucket/path/to/dataset" ), result );
+		assertTrue( errors.isEmpty(), "Unexpected errors: " + errors );
+	}
+
+	@Test
 	void unsupportedSchemeReportsError()
 	{
 		assertNull( ClipboardUtils.stringToUri("ftp://example.com/foo.zarr", errorHandler ) );

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/util/ClipboardUtilsTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/util/ClipboardUtilsTest.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -128,7 +128,13 @@ class ClipboardUtilsTest
 		assertTrue( errors.get( 0 ).contains( "ftp" ) );
 	}
 
-	// --- readClipboard() and parseClipboardUri(Consumer) via system clipboard ---
+	@Test
+	void fileUriWithHostReportsError()
+	{
+		assertNull( ClipboardUtils.stringToUri( "file://some-server/path/to/data.zarr", errorHandler ) );
+		assertEquals( 1, errors.size() );
+		assertTrue( errors.get( 0 ).contains( "host" ), "Unexpected message: " + errors.get( 0 ) );
+	}
 
 	@Test
 	void systemClipboardWithHttpsUrlReturnsUri()

--- a/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
+++ b/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
@@ -60,8 +60,7 @@ import ome.zarr.fiji.plugins.PyramidalService;
 import ome.zarr.fiji.open.exceptions.NonExistingResolutionLevelException;
 import ome.zarr.fiji.open.exceptions.NotASingleScaleImageException;
 import ome.zarr.fiji.util.BdvUtils;
-import dev.zarr.zarrjava.store.StoreException;
-import org.janelia.saalfeldlab.n5.N5Exception;
+import ome.zarr.imglib2.exceptions.StoreAccessException;
 
 /**
  * Backend-reader-agnostic opener for OME-Zarr datasets.
@@ -247,7 +246,7 @@ public class ZarrOpener
 			showSingleScaleNotSupported();
 			// TODO: openSingleScaleImage( singleScaleOpener ) when single-scale support is added
 		}
-		catch ( StoreException | N5Exception e )
+		catch ( StoreAccessException e )
 		{
 			showStoreAccessError( e );
 		}

--- a/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
+++ b/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
@@ -156,6 +156,7 @@ public class ZarrOpener
 						final PyramidContents< ? > contents = getContents();
 						final PyramidalDataset dataset = new PyramidalDataset( context, contents, preferredResolutionLevel );
 						context.getService( UIService.class ).show( dataset );
+						context.getService( PyramidalService.class ).registerImageJDataset( dataset );
 						logger.info( "Opened dataset in ImageJ: {}", inputUri );
 						return null;
 					},
@@ -191,6 +192,7 @@ public class ZarrOpener
 							throw new NonExistingResolutionLevelException( resolutionLevel, contents.numResolutionLevels() );
 						final PyramidalDataset dataset = new PyramidalDataset( context, contents, resolutionLevel );
 						context.getService( UIService.class ).show( dataset );
+						context.getService( PyramidalService.class ).registerImageJDataset( dataset );
 						logger.info( "Opened dataset at resolution level {} in ImageJ: {}", resolutionLevel, inputUri );
 						return null;
 					},

--- a/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
+++ b/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
@@ -60,6 +60,8 @@ import ome.zarr.fiji.plugins.PyramidalService;
 import ome.zarr.fiji.open.exceptions.NonExistingResolutionLevelException;
 import ome.zarr.fiji.open.exceptions.NotASingleScaleImageException;
 import ome.zarr.fiji.util.BdvUtils;
+import dev.zarr.zarrjava.store.StoreException;
+import org.janelia.saalfeldlab.n5.N5Exception;
 
 /**
  * Backend-reader-agnostic opener for OME-Zarr datasets.
@@ -245,6 +247,10 @@ public class ZarrOpener
 			showSingleScaleNotSupported();
 			// TODO: openSingleScaleImage( singleScaleOpener ) when single-scale support is added
 		}
+		catch ( StoreException | N5Exception e )
+		{
+			showStoreAccessError( e );
+		}
 		catch ( IllegalArgumentException | JsonSyntaxException e )
 		{
 			showNonZarrError( e );
@@ -317,6 +323,12 @@ public class ZarrOpener
 		errorHandler.accept( "Could not open dataset as image: " + inputUri + "\n\n"
 				+ "Consider opening one level higher or lower in the hierarchy instead." );
 		logger.warn( "Could not open dataset as single resolution image: {}. Error message: {}", inputUri, e.getMessage() );
+	}
+
+	private void showStoreAccessError( final Exception e )
+	{
+		errorHandler.accept( "Could not access the dataset at: " + inputUri + "\n\n" + e.getMessage() );
+		logger.warn( "Store access failed for {}: {}", inputUri, e.getMessage() );
 	}
 
 	private void showNonZarrError( final Exception e )

--- a/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
+++ b/ome-zarr-fiji/src/main/java/ome/zarr/fiji/open/ZarrOpener.java
@@ -257,35 +257,6 @@ public class ZarrOpener
 		return null;
 	}
 
-	/**
-	 * Opens the dataset and applies a caller-supplied function to it: the
-	 * multiscale function receives a {@link PyramidalDataset} at the preferred
-	 * resolution level, the single-scale function an {@link Img} (single-scale
-	 * support is still pending). Returns the function's result, or {@code null}
-	 * if opening failed.
-	 */
-	public Object openImage( final Function< PyramidalDataset, Object > multiScaleImageOpener,
-			final Function< Img< ? >, Object > singleScaleImageOpener )
-	{
-		try
-		{
-			return openPyramidImage(
-					() -> {
-						final PyramidContents< ? > contents = getContents();
-						final PyramidalDataset dataset = new PyramidalDataset( context, contents, preferredResolutionLevel );
-						final Object result = multiScaleImageOpener.apply( dataset );
-						logger.info( "Opened dataset: {}", inputUri );
-						return result;
-					},
-					singleScaleImageOpener );
-		}
-		catch ( NoMatchingResolutionException e )
-		{
-			showNonMatchingResolutionError( e );
-		}
-		return null;
-	}
-
 	private Object openSingleScaleImage( final Function< Img< ? >, Object > singleScaleImageOpener ) throws NotASingleScaleImageException
 	{
 		N5Reader reader = new N5Factory().openReader( inputUri.toString() );

--- a/ome-zarr-fiji/src/main/java/ome/zarr/fiji/plugins/PyramidalService.java
+++ b/ome-zarr-fiji/src/main/java/ome/zarr/fiji/plugins/PyramidalService.java
@@ -168,10 +168,25 @@ public class PyramidalService extends AbstractService implements SciJavaService
 	}
 
 	/** Records {@code dataset} as the active pyramidal, replacing any previously active one. */
-	void notifyBdvWindowFocused( final Pyramidal dataset )
+	void notifyBdvWindowFocused( final Pyramidal pyramidal )
 	{
-		logger.trace( "BDV window focused: {}", dataset );
-		activePyramidal.set( dataset );
+		logger.trace( "BDV window focused: {}", pyramidal );
+		activePyramidal.set( pyramidal );
+		logger.trace( "Active pyramidal set to: {}", activePyramidal.get() );
+	}
+
+	/**
+	 * Records the given {@code pyramidal} as the active pyramidal immediately when it is opened in an
+	 * ImageJ window, without waiting for the asynchronous AWT {@code "activeWindow"} focus
+	 * event to arrive at the new {@link ImageWindow}. This mirrors the synchronous registration
+	 * that {@link #registerBdvWindow} performs for BDV windows. So a freshly opened pyramidal is
+	 * the active pyramidal as soon as the open call returns rather than only once the native
+	 * windowing system delivers focus (which may be delayed or never happen under load).
+	 */
+	public void registerImageJDataset( final Pyramidal pyramidal )
+	{
+		logger.trace( "ImageJ dataset opened: {}", pyramidal );
+		activePyramidal.set( pyramidal );
 		logger.trace( "Active pyramidal set to: {}", activePyramidal.get() );
 	}
 

--- a/ome-zarr-imglib2/src/main/java/ome/zarr/imglib2/ZarrUtils.java
+++ b/ome-zarr-imglib2/src/main/java/ome/zarr/imglib2/ZarrUtils.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,9 +40,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Utility methods for detecting Zarr datasets.
- * Handles {@link Path} checks and scheme-agnostic {@link URI} probing
- * ({@code file:} and {@code http(s):}).
+ * Utility methods for detecting Zarr datasets on the local filesystem and over
+ * HTTP. See {@link #isZarr(URI)} for the schemes that can be probed and why
+ * others (e.g. {@code s3:}) cannot.
  */
 public class ZarrUtils
 {
@@ -88,10 +88,28 @@ public class ZarrUtils
 	}
 
 	/**
-	 * @param uri location to probe
-	 * @return {@code true} if the URI points at the root of a Zarr dataset.
-	 *   Returns {@code false} for unknown schemes, null, or any error during
-	 *   probing.
+	 * Determines whether the URI points at the root of a Zarr dataset.
+	 * <p>
+	 * Supported schemes:
+	 * <ul>
+	 *   <li>{@code file:} or no scheme – checks for well-known Zarr metadata
+	 *       files on the local filesystem</li>
+	 *   <li>{@code http:} / {@code https:} – sends HTTP HEAD requests for
+	 *       well-known Zarr metadata files</li>
+	 * </ul>
+	 * Other schemes (e.g. {@code s3:}) always return {@code false}.<br>
+	 * They are not probed because doing so cheaply is not possible: it would require
+	 * creating an (authenticated), scheme-specific client (such as an S3 client)
+	 * purely to look for metadata files, only to discard it and
+	 * build another client for the actual open later.<br>
+	 * Callers that accept such schemes should therefore bypass this method and
+	 * attempt to open the dataset directly, letting the open method
+	 * report a clear error if the location turns out not to be OME-Zarr.
+	 *
+	 * @param uri location to probe; may be {@code null}
+	 * @return {@code true} if the URI points at the root of a Zarr dataset,
+	 *         {@code false} for unsupported schemes, {@code null}, or any error
+	 *         during probing
 	 */
 	public static boolean isZarr( final URI uri )
 	{

--- a/ome-zarr-imglib2/src/main/java/ome/zarr/imglib2/exceptions/StoreAccessException.java
+++ b/ome-zarr-imglib2/src/main/java/ome/zarr/imglib2/exceptions/StoreAccessException.java
@@ -1,0 +1,46 @@
+/*-
+ * #%L
+ * OME-Zarr extras for Fiji
+ * %%
+ * Copyright (C) 2022 - 2026 SciJava developers
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package ome.zarr.imglib2.exceptions;
+
+/**
+ * Thrown when a pyramid backend cannot access the OME-Zarr store itself —
+ * e.g. an S3 authentication failure, a missing bucket, a network error, or any
+ * other failure that prevents even opening the dataset root.
+ * <p>
+ * This is a backend-agnostic wrapper so that the Fiji layer can report store
+ * access failures without depending on backend-specific exception types.
+ */
+public class StoreAccessException extends RuntimeException
+{
+
+	public StoreAccessException( final String path, final Throwable cause )
+	{
+		super( "Cannot access OME-Zarr store at: " + path, cause );
+	}
+}

--- a/ome-zarr-n5/pom.xml
+++ b/ome-zarr-n5/pom.xml
@@ -115,6 +115,12 @@
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-universe</artifactId>
 		</dependency>
+		<!-- S3 backend: N5Factory handles s3:// URIs via n5-aws-s3 -->
+		<dependency>
+			<groupId>org.janelia.saalfeldlab</groupId>
+			<artifactId>n5-aws-s3</artifactId>
+			<version>${n5-aws-s3.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
+++ b/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
@@ -103,9 +103,11 @@ public class N5PyramidBackend implements PyramidBackend
 		final OmeNgffMetadata metadata;
 		try
 		{
-			reader = new N5Factory()
-					.s3Configuration( builder -> builder.region( Region.US_EAST_1 ) )
-					.openReader( inputUri.toString() );
+			final N5Factory factory = new N5Factory();
+			// The region default only matters for s3:// URIs.
+			if ( "s3".equalsIgnoreCase( inputUri.getScheme() ) )
+				factory.s3Configuration( builder -> builder.region( Region.US_EAST_1 ) );
+			reader = factory.openReader( inputUri.toString() );
 			metadata = readMetadata( reader, treeNode, inputUri );
 		}
 		catch ( N5Exception e )

--- a/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
+++ b/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
@@ -35,6 +35,7 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.util.Cast;
 
 import org.janelia.saalfeldlab.n5.DataType;
+import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.imglib2.N5Utils;
 import org.janelia.saalfeldlab.n5.universe.N5DatasetDiscoverer;
@@ -67,6 +68,7 @@ import ome.zarr.imglib2.PyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
 import ome.zarr.imglib2.exceptions.MultiImageDatasetException;
 import ome.zarr.imglib2.exceptions.NotAMultiscaleImageException;
+import ome.zarr.imglib2.exceptions.StoreAccessException;
 import ome.zarr.imglib2.metadata.AxisCalibration;
 import ome.zarr.imglib2.metadata.Omero;
 
@@ -96,11 +98,23 @@ public class N5PyramidBackend implements PyramidBackend
 	@Override
 	public < T extends NativeType< T > & RealType< T > > PyramidContents< T > load( final URI inputUri )
 	{
-		final N5Reader reader = new N5Factory()
-				.s3Configuration( builder -> builder.region( Region.US_EAST_1 ) )
-				.openReader( inputUri.toString() );
+		final N5Reader reader;
 		final N5TreeNode treeNode = new N5TreeNode( "" );
-		final OmeNgffMetadata metadata = readMetadata( reader, treeNode, inputUri );
+		final OmeNgffMetadata metadata;
+		try
+		{
+			reader = new N5Factory()
+					.s3Configuration( builder -> builder.region( Region.US_EAST_1 ) )
+					.openReader( inputUri.toString() );
+			metadata = readMetadata( reader, treeNode, inputUri );
+		}
+		catch ( N5Exception e )
+		{
+			// Store-level failure (e.g., S3 auth failure, missing bucket, network
+			// error) before we could reach the dataset. Wrap in a backend-agnostic
+			// exception.
+			throw new StoreAccessException( inputUri.toString(), e );
+		}
 		final Multiscale multiscale = buildMultiscale( metadata, 0 );
 		final Omero omero = readOmeroMetadata( reader, treeNode );
 

--- a/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
+++ b/ome-zarr-n5/src/main/java/ome/zarr/n5/N5PyramidBackend.java
@@ -60,6 +60,8 @@ import java.util.List;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
+import software.amazon.awssdk.regions.Region;
+
 import ome.zarr.imglib2.Affine3DUtils;
 import ome.zarr.imglib2.PyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
@@ -94,7 +96,9 @@ public class N5PyramidBackend implements PyramidBackend
 	@Override
 	public < T extends NativeType< T > & RealType< T > > PyramidContents< T > load( final URI inputUri )
 	{
-		final N5Reader reader = new N5Factory().openReader( inputUri.toString() );
+		final N5Reader reader = new N5Factory()
+				.s3Configuration( builder -> builder.region( Region.US_EAST_1 ) )
+				.openReader( inputUri.toString() );
 		final N5TreeNode treeNode = new N5TreeNode( "" );
 		final OmeNgffMetadata metadata = readMetadata( reader, treeNode, inputUri );
 		final Multiscale multiscale = buildMultiscale( metadata, 0 );

--- a/ome-zarr-zarrjava/pom.xml
+++ b/ome-zarr-zarrjava/pom.xml
@@ -107,7 +107,6 @@
 			<groupId>dev.zarr</groupId>
 			<artifactId>zarr-java</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>

--- a/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
+++ b/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
@@ -6,13 +6,13 @@
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -55,6 +55,7 @@ import dev.zarr.zarrjava.store.FilesystemStore;
 import dev.zarr.zarrjava.store.HttpStore;
 import dev.zarr.zarrjava.store.S3Store;
 import dev.zarr.zarrjava.store.Store;
+import dev.zarr.zarrjava.store.StoreException;
 import dev.zarr.zarrjava.store.StoreHandle;
 
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
@@ -87,6 +88,7 @@ import org.slf4j.LoggerFactory;
 import ome.zarr.imglib2.exceptions.MultiImageDatasetException;
 import ome.zarr.imglib2.exceptions.NotAMultiscaleImageException;
 import ome.zarr.imglib2.exceptions.PyramidLevelAccessException;
+import ome.zarr.imglib2.exceptions.StoreAccessException;
 import ome.zarr.imglib2.PyramidBackend;
 import ome.zarr.imglib2.PyramidContents;
 import ome.zarr.imglib2.metadata.AxisCalibration;
@@ -244,7 +246,8 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 		{
 			final S3Client s3 = S3Client.builder().region( Region.US_EAST_1 )
 					.credentialsProvider( AwsCredentialsProviderChain.builder()
-							.credentialsProviders( DefaultCredentialsProvider.builder().build(), AnonymousCredentialsProvider.create() ).build() )
+							.credentialsProviders( DefaultCredentialsProvider.builder().build(), AnonymousCredentialsProvider.create() )
+							.build() )
 					.build();
 			final String bucket = inputUri.getHost();
 			final String rawPath = inputUri.getPath();
@@ -253,7 +256,17 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 		}
 		else
 			throw new IllegalArgumentException( "Unsupported URI scheme '" + scheme + "' for OME-Zarr location: " + inputUri );
-		return openMultiscaleImageFromHandle( store.resolve() );
+		try
+		{
+			return openMultiscaleImageFromHandle( store.resolve() );
+		}
+		catch ( StoreException e )
+		{
+			// Store-level failure (e.g., S3 auth failure, missing bucket, network
+			// error) before we could reach the dataset. Wrap in a backend-agnostic
+			// exception.
+			throw new StoreAccessException( inputUri.toString(), e );
+		}
 	}
 
 	private MultiscaleImage openMultiscaleImageFromHandle( final StoreHandle handle )

--- a/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
+++ b/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
@@ -53,8 +53,11 @@ import dev.zarr.zarrjava.experimental.ome.metadata.transform.ScaleCoordinateTran
 import dev.zarr.zarrjava.experimental.ome.metadata.transform.TranslationCoordinateTransformation;
 import dev.zarr.zarrjava.store.FilesystemStore;
 import dev.zarr.zarrjava.store.HttpStore;
+import dev.zarr.zarrjava.store.S3Store;
 import dev.zarr.zarrjava.store.Store;
 import dev.zarr.zarrjava.store.StoreHandle;
+
+import software.amazon.awssdk.services.s3.S3Client;
 
 import net.imglib2.cache.img.CachedCellImg;
 import net.imglib2.cache.img.ReadOnlyCachedCellImgFactory;
@@ -233,6 +236,14 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 			store = new FilesystemStore( Paths.get( inputUri ) );
 		else if ( "http".equalsIgnoreCase( scheme ) || "https".equalsIgnoreCase( scheme ) )
 			store = new HttpStore( inputUri.toString() );
+		else if ( "s3".equalsIgnoreCase( scheme ) )
+		{
+			final S3Client s3 = S3Client.create();
+			final String bucket = inputUri.getHost();
+			final String rawPath = inputUri.getPath();
+			final String keyPrefix = rawPath == null ? "" : rawPath.replaceFirst( "^/", "" );
+			store = new S3Store( s3, bucket, keyPrefix.isEmpty() ? null : keyPrefix );
+		}
 		else
 			throw new IllegalArgumentException( "Unsupported URI scheme '" + scheme + "' for OME-Zarr location: " + inputUri );
 		return openMultiscaleImageFromHandle( store.resolve() );

--- a/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
+++ b/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
@@ -57,6 +57,9 @@ import dev.zarr.zarrjava.store.S3Store;
 import dev.zarr.zarrjava.store.Store;
 import dev.zarr.zarrjava.store.StoreHandle;
 
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import net.imglib2.cache.img.CachedCellImg;
@@ -238,7 +241,13 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 			store = new HttpStore( inputUri.toString() );
 		else if ( "s3".equalsIgnoreCase( scheme ) )
 		{
-			final S3Client s3 = S3Client.create();
+			final S3Client s3 = S3Client.builder()
+					.credentialsProvider( AwsCredentialsProviderChain.builder()
+							.credentialsProviders(
+									DefaultCredentialsProvider.builder().build(),
+									AnonymousCredentialsProvider.create() )
+							.build() )
+					.build();
 			final String bucket = inputUri.getHost();
 			final String rawPath = inputUri.getPath();
 			final String keyPrefix = rawPath == null ? "" : rawPath.replaceFirst( "^/", "" );

--- a/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
+++ b/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
@@ -61,6 +61,7 @@ import dev.zarr.zarrjava.store.StoreHandle;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -260,11 +261,9 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 		{
 			return openMultiscaleImageFromHandle( store.resolve() );
 		}
-		catch ( StoreException e )
+		catch ( StoreException | SdkException e )
 		{
-			// Store-level failure (e.g., S3 auth failure, missing bucket, network
-			// error) before we could reach the dataset. Wrap in a backend-agnostic
-			// exception.
+			// Store-level failures. Wrap them in a backend-agnostic exception.
 			throw new StoreAccessException( inputUri.toString(), e );
 		}
 	}

--- a/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
+++ b/ome-zarr-zarrjava/src/main/java/ome/zarr/zarrjava/ZarrJavaPyramidBackend.java
@@ -60,6 +60,7 @@ import dev.zarr.zarrjava.store.StoreHandle;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import net.imglib2.cache.img.CachedCellImg;
@@ -241,12 +242,9 @@ public class ZarrJavaPyramidBackend implements PyramidBackend
 			store = new HttpStore( inputUri.toString() );
 		else if ( "s3".equalsIgnoreCase( scheme ) )
 		{
-			final S3Client s3 = S3Client.builder()
+			final S3Client s3 = S3Client.builder().region( Region.US_EAST_1 )
 					.credentialsProvider( AwsCredentialsProviderChain.builder()
-							.credentialsProviders(
-									DefaultCredentialsProvider.builder().build(),
-									AnonymousCredentialsProvider.create() )
-							.build() )
+							.credentialsProviders( DefaultCredentialsProvider.builder().build(), AnonymousCredentialsProvider.create() ).build() )
 					.build();
 			final String bucket = inputUri.getHost();
 			final String rawPath = inputUri.getPath();


### PR DESCRIPTION
Enables opening `s3://bucket/path` URIs in both the ZarrJava and N5 backends.

**What's included:**
- Accept `s3://` URIs in `ClipboardUtils` and skip the `isZarr()` probe for them (which would require a short-lived S3 client just for detection)
- `ZarrJavaPyramidBackend`: builds an AWS SDK `S3Client` (default region `US_EAST_1`; standard AWS credential chain with an anonymous-credentials fallback) and constructs a zarr-java `S3Store` from the URI's host and path. The AWS SDK ships transitively with `zarr-java`.
- `N5PyramidBackend`: relies on `N5Factory`'s existing S3 support (via `n5-aws-s3`), only passing `Region.US_EAST_1` as the default region so environments without `~/.aws/config` still work. The `n5-aws-s3` dependency was added to the `ome-zarr-n5` module.

**Error handling:**
- Store-access failures (S3 auth failures, missing buckets, network errors, …) are RuntimeExceptions that previously escaped every catch block and surfaced as an unhandled exception in Fiji. Each backend now wraps them, in `load()`, into a backend-agnostic `StoreAccessException` (added to `ome-zarr-imglib2`): `ZarrJavaPyramidBackend` wraps zarr-java's `StoreException`, `N5PyramidBackend` wraps N5's `N5Exception` thrown while opening the reader / reading multiscale metadata.
- The Fiji opener (`ZarrOpener`) catches the single `StoreAccessException` and reports it as a user-facing error. This keeps the Fiji layer decoupled from the concrete backends.

**Authentication:**
* Works with public (anonymous) buckets and with private buckets whose credentials are available through the standard AWS chain (`~/.aws/credentials`, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars, or instance role credentials).

**Not yet included:**
* No UI to enter an S3 URI, bucket, region, or credentials. Users must paste an `s3://` URI via the existing clipboard/drag-and-drop path.
* There is currently no API to inject custom credentials programmatically.

* [x] Can be tested with this URI from the open organelle project: **s3://janelia-cosem-datasets/jrc_mus-choroid-plexus-3/jrc_mus-choroid-plexus-3.zarr/recon-1/em/fibsem-uint8**
