### PR TITLE
Conformance testbed tool, report table and reference datasets (rebased onto module split)

### DIFF
--- a/ome-zarr-fiji-ui/pom.xml
+++ b/ome-zarr-fiji-ui/pom.xml
@@ -153,5 +153,12 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- ASCII table rendering for conformance test report -->
+		<dependency>
+			<groupId>com.github.freva</groupId>
+			<artifactId>ascii-table</artifactId>
+			<version>1.2.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ConformanceTest.java
+++ b/ome-zarr-fiji-ui/src/test/java/ome/zarr/fijiui/open/ConformanceTest.java
@@ -1,0 +1,484 @@
+package ome.zarr.fijiui.open;
+
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.type.numeric.real.DoubleType;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.scijava.Context;
+import org.scijava.display.DisplayService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ome.zarr.fijiui.open.options.ZarrOpenBehavior;
+import ome.zarr.fijiui.open.options.ZarrOpeningSettings;
+import ome.zarr.fijiui.open.options.ZarrReaderBackend;
+import ome.zarr.fiji.PyramidalDataset;
+import ome.zarr.imglib2.PyramidContents;
+import ome.zarr.imglib2.metadata.AxisCalibration;
+import ome.zarr.ZarrTestUtils;
+
+import javax.swing.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import com.github.freva.asciitable.AsciiTable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ConformanceTest
+{
+	private static final Logger logger = LoggerFactory.getLogger( MethodHandles.lookup().lookupClass() );
+
+	static Stream< ZarrReaderBackend > readerBackends()
+	{
+		return Stream.of( ZarrReaderBackend.N5, ZarrReaderBackend.ZARR_JAVA );
+	}
+
+	static Stream< TestDataset > readerTestDatasets()
+	{
+		//the .csv lives in the shared test resources (test-shared/resources),
+		//so it is resolved from the test classpath rather than an absolute path
+		final Path csvFile;
+		try
+		{
+			csvFile = ZarrTestUtils.resourcePath( "ome/zarr/testdata/conformance_testing/testbed_datasets.csv" );
+		}
+		catch ( URISyntaxException e )
+		{
+			throw new RuntimeException( "Could not locate the conformance testbed .csv resource.", e );
+		}
+
+		List< TestDataset > datasets = new ArrayList<>( 200 );
+		try (BufferedReader br = Files.newBufferedReader( csvFile ))
+		{
+			String line;
+			boolean skipFirstLine = true;
+			while ( ( line = br.readLine() ) != null )
+			{
+				String[] fields = line.split( ",", -1 ); // -1 preserves trailing empty fields
+				if ( !skipFirstLine )
+					datasets.add( new TestDataset( fields ) );
+				else
+					skipFirstLine = false;
+			}
+		}
+		catch ( IOException e )
+		{
+			throw new RuntimeException( "Failed while reading the .csv file.", e );
+		}
+		return datasets.stream();
+	}
+
+	static Stream< Arguments > testCasesFeeder()
+	{
+		return readerTestDatasets()
+				.filter( dataset -> dataset.getOmeNgffVersion() >= 0.4 )
+				.limit( 2 )
+				.flatMap( dataset -> readerBackends().map( backend -> Arguments.of( backend, dataset ) ) );
+	}
+
+	@Disabled( "Conformance testing is explicitly opted out from the automated testing. Please, run manually." )
+	@ParameterizedTest
+	@MethodSource( "testCasesFeeder" )
+	void testOpenAndCheckDatasetParams( ZarrReaderBackend backend, TestDataset testDataset )
+			throws URISyntaxException, InterruptedException, InvocationTargetException
+	{
+		try (Context context = new Context())
+		{
+			logger.debug( "Conformance testing dataset: study = {}\n  at URL: {}",
+					testDataset.getStudy(), testDataset.getZarrURL() );
+
+			final URI testDatasetURI = new URI( testDataset.getZarrURL() );
+
+			final ZarrOpeningSettings settings = new ZarrOpeningSettings();
+			settings.setReaderBackend( backend );
+			//open the lowest available resolution as a standard IJ window
+			//(or open with BDV; just be aware that in order to display anything,
+			//both displays (IJ, BDV) will start fetching/downloading the pixels,
+			//so avoid fetching the finest/largests resolution; while BDV would
+			//probably start with some worse/smaller resolution, it may decide
+			//later to fetch a better one, despite our use case doesn't need it,
+			//thus IJ window has been chosen to use in this test)
+			settings.setPreferredMaxWidth( 600 );
+			settings.setCurrentChoice( ZarrOpenBehavior.IMAGEJ_CUSTOM_RESOLUTION );
+
+			//open URL, read the dataset, and retrieve it as an opened Dataset
+			assertDoesNotThrow( () -> new ZarrOpenActions( testDatasetURI, context, settings ).openIJWithImage(),
+					"Failed opening dataset '" + testDataset.getStudy() + "' with IJ." );
+
+			DatasetService datasetService = context.getService( DatasetService.class );
+			assertEquals( 1, datasetService.getDatasets().size(),
+					"After opening, no Dataset is available in Fiji." );
+
+			Dataset d = datasetService.getDatasets().get( 0 );
+			assertInstanceOf( PyramidalDataset.class, d,
+					"After opening, incorrect Dataset is available in Fiji." );
+
+			final PyramidalDataset pyramidalDataset = ( PyramidalDataset ) d;
+			//the multi-resolution pyramid and its metadata; note that the opened
+			//IJ window may show a coarser resolution level (see setPreferredMaxWidth
+			//above), but the reference values in the .csv describe the full/base
+			//resolution, so all size/scale/level checks below query the contents
+			//directly at the base resolution level (index 0), not the IJ window
+			final PyramidContents< ? > contents = pyramidalDataset.getPyramidContents();
+
+			//base-resolution image; note that no pixels are actively loaded while
+			//we hold now a variable of a (lazily loaded) Imglib2 img-like RAI
+			final RandomAccessibleInterval< ? > rai = contents.asImg( 0 );
+
+			//finally, the conformance testing:
+			assertEquals( testDataset.getSizeX(), rai.dimension( contents.axisIndex( AxisCalibration.X ) ),
+					"Mismatch in X-axis size." );
+			assertEquals( testDataset.getSizeY(), rai.dimension( contents.axisIndex( AxisCalibration.Y ) ),
+					"Mismatch in Y-axis size." );
+			final long sizeZ = contents.hasAxis( AxisCalibration.Z )
+					? rai.dimension( contents.axisIndex( AxisCalibration.Z ) ) : 1;
+			assertEquals( testDataset.getSizeZ(), sizeZ, "Mismatch in Z-axis size." );
+			if ( testDataset.getSizeC() != -1 )
+				assertEquals( testDataset.getSizeC(), contents.numChannels(),
+						"Mismatch in number of channels." );
+			if ( testDataset.getSizeT() != -1 )
+				assertEquals( testDataset.getSizeT(), contents.numTimepoints(),
+						"Mismatch in number of time points." );
+
+			StringBuilder axes = new StringBuilder();
+			for ( int i = 0; i < pyramidalDataset.getImgPlus().numDimensions(); ++i )
+				axes.append( pyramidalDataset.getImgPlus().axis( i ).type().toString().charAt( 0 ) );
+			assertEquals( testDataset.getAxes(), axes.toString(), "Mismatch in understanding the order of axes." );
+
+			//TODO: wells, fields
+
+			final String refType = testDataset.getDataType();
+			if ( refType != null && !refType.isEmpty() )
+				checkPixelTypes( refType, pyramidalDataset );
+
+			final double ACCURACY_DELTA = 0.00001f;
+			if ( testDataset.getScaleX() != -1 )
+				assertEquals( testDataset.getScaleX(), scaleAlongAxis( contents, AxisCalibration.X ),
+						ACCURACY_DELTA, "Mismatch in extracted pixel resolution along X-axis." );
+			if ( testDataset.getScaleY() != -1 )
+				assertEquals( testDataset.getScaleY(), scaleAlongAxis( contents, AxisCalibration.Y ),
+						ACCURACY_DELTA, "Mismatch in extracted pixel resolution along Y-axis." );
+			if ( testDataset.getScaleZ() != -1 )
+				assertEquals( testDataset.getScaleZ(), scaleAlongAxis( contents, AxisCalibration.Z ),
+						ACCURACY_DELTA, "Mismatch in extracted pixel resolution along Z-axis." );
+
+			if ( testDataset.getNumberOfResLevels() != -1 )
+				assertEquals( testDataset.getNumberOfResLevels(), contents.numResolutionLevels(),
+						"Mismatch in extracted number of resolution levels." );
+
+			//clean up: wait for the IJ window to clam down, get a reference on it, and close it
+			SwingUtilities.invokeAndWait( () -> {} );
+			DisplayService displayService = context.getService( DisplayService.class );
+			assertNotNull( displayService.getActiveDisplay(), "Internal error!" );
+			displayService.getActiveDisplay().close();
+		}
+	}
+
+	Optional< String > testOpenAndCheckDatasetParamsWrapper( ZarrReaderBackend backend, TestDataset testDataset )
+	{
+		try
+		{
+			testOpenAndCheckDatasetParams( backend, testDataset );
+			return Optional.empty();
+		}
+		catch ( Throwable t )
+		{
+			return Optional.of( t.getClass().getSimpleName() + ": " + t.getMessage() );
+		}
+	}
+
+	@Disabled( "Conformance testing is explicitly opted out from the automated testing. Please, run manually." )
+	@Test
+	void reportSuccessRateAndPrintTable()
+	{
+		final List< String[] > rows = new ArrayList<>();
+		//
+		final int[] stats = { 0, 0 };
+		final int passedIdx = 0;
+		final int totalIdx = 1;
+
+		testCasesFeeder().forEach( arguments -> {
+			ZarrReaderBackend backend = ( ZarrReaderBackend ) arguments.get()[ 0 ];
+			TestDataset testDataset = ( TestDataset ) arguments.get()[ 1 ];
+
+			final Optional< String > result = testOpenAndCheckDatasetParamsWrapper( backend, testDataset );
+			rows.add( new String[] {
+					testDataset.condensedDesription(),
+					backend.toString(),
+					result.isPresent() ? "FAIL" : "PASS",
+					result.orElse( "" )
+			} );
+			if ( !result.isPresent() )
+				stats[ passedIdx ]++;
+			stats[ totalIdx ]++;
+		} );
+
+		int passed = stats[ passedIdx ];
+		int total = stats[ totalIdx ];
+
+		final String[] headers = { "Dataset", "Backend", "Result", "Reason" };
+		System.out.println( AsciiTable.getTable( headers, rows.toArray( new String[ 0 ][] ) ) );
+		System.out.printf( "%nPassed: %d / %d%n", passed, total );
+	}
+
+	/**
+	 * Pixel spacing of the full/base resolution level along the axis with the
+	 * given OME-Zarr name, or {@code -1} if that axis is not present.
+	 */
+	private static double scaleAlongAxis( final PyramidContents< ? > contents, final String axisName )
+	{
+		final int idx = contents.axisIndex( axisName );
+		return idx < 0 ? -1.0 : contents.axesPerLevel[ 0 ][ idx ].scale;
+	}
+
+	private static void checkPixelTypes( final String refType, final PyramidalDataset pyramidalDataset )
+	{
+		final RealType< ? > imglibType = pyramidalDataset.getPyramidContents().type;
+
+		if ( refType.startsWith( "float" ) )
+		{
+			if ( refType.contains( "32" ) )
+			{
+				assertInstanceOf( FloatType.class, imglibType );
+			}
+			else if ( refType.contains( "64" ) )
+			{
+				assertInstanceOf( DoubleType.class, imglibType );
+			}
+			else
+			{
+				logger.error( "Unrecognized reference float type '{}'. Internal error.", refType );
+			}
+		}
+		else if ( refType.contains( "int" ) )
+		{
+			if ( refType.startsWith( "u" ) )
+			{
+				//unsigned integers
+				if ( refType.endsWith( "8" ) )
+				{
+					assertInstanceOf( UnsignedByteType.class, imglibType );
+				}
+				else if ( refType.endsWith( "16" ) )
+				{
+					assertInstanceOf( UnsignedShortType.class, imglibType );
+				}
+				else if ( refType.endsWith( "32" ) )
+				{
+					assertInstanceOf( UnsignedIntType.class, imglibType );
+				}
+				else if ( refType.endsWith( "64" ) )
+				{
+					assertInstanceOf( UnsignedLongType.class, imglibType );
+				}
+				else
+				{
+					logger.error( "Unrecognized reference integer type '{}'. Internal error.", refType );
+				}
+			}
+			else
+			{
+				//signed integers
+				if ( refType.endsWith( "8" ) )
+				{
+					assertInstanceOf( ByteType.class, imglibType );
+				}
+				else if ( refType.endsWith( "16" ) )
+				{
+					assertInstanceOf( ShortType.class, imglibType );
+				}
+				else if ( refType.endsWith( "32" ) )
+				{
+					assertInstanceOf( IntType.class, imglibType );
+				}
+				else if ( refType.endsWith( "64" ) )
+				{
+					assertInstanceOf( LongType.class, imglibType );
+				}
+				else
+				{
+					logger.error( "Unrecognized reference integer type '{}'. Internal error.", refType );
+				}
+			}
+		}
+		else
+		{
+			logger.error( "Unrecognized reference type '{}'. Internal error.", refType );
+		}
+	}
+
+	/**
+	 * Internal record of one dataset for the conformance testing.
+	 * It contains a reference (URL) to a dataset and its OME-Zarr version,
+	 * and a couple of reference, basic parameters of that dataset such as
+	 * number of resolution levels or size along the x-axis, etc. Typical
+	 * usage is to open the dataset in a tested reader, and check reader's
+	 * values against the reference ones from this class.
+	 */
+	static class TestDataset
+	{
+		// @formatter:off
+		private final float omeNgffVersion;
+		private final String zarrURL;
+
+		private final String dataType;
+		private final int sizeX;
+		private final int sizeY;
+		private final int sizeZ;
+		private final int sizeC;
+		private final int sizeT;
+		private final String axes;
+
+		private final float scaleX;
+		private final float scaleY;
+		private final float scaleZ;
+
+		private final int numberOfResLevels;
+		private final int wells;
+		private final int fields;
+
+		private final String license;
+		private final String study;
+		// @formatter:off
+
+		public TestDataset( String... s )
+		{
+			this( s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11], s[12], s[13], s[14], s[15], s[16] );
+		}
+
+		public TestDataset( //the order as it is in the CSV file!!!
+		                    String omeNgffVersion, String filePath, String sizeX,
+		                    String sizeY, String sizeZ, String sizeC, String sizeT,
+		                    String axes, String wells, String fields,
+		                    String license, String study,
+		                    String pixelType, String scaleX, String scaleY, String scaleZ,
+		                    String numberOfResLevels )
+		{
+			// @formatter:off
+			this.omeNgffVersion = Float.parseFloat( omeNgffVersion ); //let fail if the number is not parseable/available !
+			this.zarrURL = filePath;
+
+			this.dataType = pixelType;
+			this.sizeX = getIntOrMinusOne( sizeX );
+			this.sizeY = getIntOrMinusOne( sizeY );
+			this.sizeZ = getIntOrMinusOne( sizeZ );
+			this.sizeC = getIntOrMinusOne( sizeC );
+			this.sizeT = getIntOrMinusOne( sizeT );
+			this.axes = axes;
+
+			this.scaleX = getFloatOrMinusOne( scaleX );
+			this.scaleY = getFloatOrMinusOne( scaleY );
+			this.scaleZ = getFloatOrMinusOne( scaleZ );
+
+			this.numberOfResLevels = getIntOrMinusOne( numberOfResLevels );
+			this.wells = getIntOrMinusOne( wells );
+			this.fields = getIntOrMinusOne( fields );
+
+			this.license = license;
+			this.study = study;
+			// @formatter:on
+		}
+
+		//internal string-to-number "cast", resilient to missing values
+		private int getIntOrMinusOne( String floatString )
+		{
+			return floatString.isEmpty() ? -1 : ( int ) Float.parseFloat( floatString );
+		}
+
+		private float getFloatOrMinusOne( String floatString )
+		{
+			return floatString.isEmpty() ? -1.0f : ( float ) Float.parseFloat( floatString );
+		}
+
+		// @formatter:off
+		// Getters, ...written in a very succinct form
+		public float getOmeNgffVersion() { return omeNgffVersion; }
+		public String getZarrURL() { return zarrURL; }
+
+		public String getDataType() { return dataType; }
+		public int getSizeX() { return sizeX; }
+		public int getSizeY() { return sizeY; }
+		public int getSizeZ() { return sizeZ; }
+		public int getSizeC() { return sizeC; }
+		public int getSizeT() { return sizeT; }
+		public String getAxes() { return axes; }
+
+		public float getScaleX() { return scaleX; }
+		public float getScaleY() { return scaleY; }
+		public float getScaleZ() { return scaleZ; }
+
+		public int getNumberOfResLevels() { return numberOfResLevels; }
+		public int getWells() { return wells; }
+		public int getFields() { return fields; }
+
+		public String getLicense() { return license; }
+		public String getStudy() { return study; }
+		// @formatter:on
+
+		@Override
+		public String toString()
+		{
+			return "TestDataset v" + omeNgffVersion + " : " + zarrURL
+					+ "\n  size=(" + sizeX + " x " + sizeY + " x " + sizeZ + " x " + sizeC + " x " + sizeT + ") [XYZCT]"
+					+ "\n  axes='" + axes + "'" + ", multiscales=" + numberOfResLevels + ", pxType=" + dataType
+					+ "\n  wells=" + wells + ", fields=" + fields
+					+ ", resolution=(" + scaleX + " x " + scaleY + " x " + scaleZ + ") [XYZ]";
+		}
+
+		public String shortedURL()
+		{
+			final URI uri = URI.create( zarrURL );
+			String scheme = uri.getScheme() != null ? uri.getScheme() + "://" : "";
+			String host = uri.getHost();
+			if ( host != null )
+			{
+				if ( host.length() > 15 )
+				{
+					host = host.substring( 0, 5 ) + "....." + host.substring( host.length() - 5 );
+				}
+				host += "/";
+			}
+			else
+				host = "";
+			String[] path = uri.getPath().split( "/" );
+			return scheme + host + "...../" + path[ path.length - 1 ];
+		}
+
+		public String condensedDesription()
+		{
+			return shortedURL() + " (" + study + ") v" + omeNgffVersion + ":"
+					+ "\n  size=(" + sizeX + " x " + sizeY + " x " + sizeZ + " x " + sizeC + " x " + sizeT + ") [XYZCT]"
+					+ ", axes='" + axes + "', pxType=" + dataType
+					+ "\n  multiscales=" + numberOfResLevels + ", wells=" + wells + ", fields=" + fields
+					+ ", resolution=(" + scaleX + " x " + scaleY + " x " + scaleZ + ") [XYZ]";
+		}
+	}
+}

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/.gitignore
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/.gitignore
@@ -1,0 +1,4 @@
+# vim swp files
+.*.sw*
+
+__pycache__

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/IDR_table.csv
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/IDR_table.csv
@@ -1,0 +1,102 @@
+OME-NGFF version,File Path,SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,Keywords,License,Study,DOI,Date added,Representative Image ID,Thumbnail
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992,4255,401,3,1,XYZCT,,,,CC BY 4.0,idr0106,,2020-11-04,12689244,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344,1024,1,2,329,XYZCT,,,,CC BY 4.0,idr0002,,2020-11-04,179706,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256,256,1,3,1,XYZCT,,,,CC BY 4.0,idr0021,,2020-11-04,1884807,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30,30,571,1,1,XYZCT,,,,CC BY 4.0,idr0023,,2020-11-04,1885619,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600,380928,1,1,1,XYZCT,,,,CC BY-NC-SA 3.0,idr0053,,2020-11-04,4495402,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024,1024,39,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001237,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024,1024,27,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001238,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024,1024,36,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001239,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,6001240,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278,263,236,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001241,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481,275,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001242,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212,218,237,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001243,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325,281,239,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001244,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220,226,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001245,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281,284,257,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001246,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-11-04,6001247,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234,269,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001248,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001249,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246,241,195,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001250,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170,163,140,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001251,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170,163,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001252,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803,1024,297,2,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001253,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393,354,51,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001254,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551,416,32,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001255,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350,372,61,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001256,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763,2860,145,4,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001257,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282,838,36,3,1,XYZCT,,,,CC BY 4.0,idr0062,,2020-11-04,6001258,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360,167424,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,https://doi.org/10.5281/zenodo.5546093,2020-11-04,9822151,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2020-11-04,9822152,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836831,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836832,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836833,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836834,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836835,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836836,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836837,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836838,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836839,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836840,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836841,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836842,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836843,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836844,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836845,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920,1920,259,4,1,XYZCT,,,,CC BY 4.0,idr0077,,2020-11-04,9836846,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636,816,156,1,1,XYZCT,,,,CC BY 4.0,idr0079,,2020-11-04,9836950,
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr,672,510,10,2,1,XYZCT,69,1,,CC BY-NC-SA 3.0,idr0004,https://doi.org/10.5281/zenodo.5741293,2020-12-01,692166,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr/G/8/0/
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr,1376,1040,16,2,1,XYZCT,96,6,,CC BY 4.0,idr0001,https://zenodo.org/record/5735098,2020-12-01,1230059,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr/E/10/0/
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr,1344,1024,1,2,329,XYZCT,96,1,,CC BY 4.0,idr0002,,2020-12-01,179693,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr/E/4/0/
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr,1080,1080,1,5,1,XYZCT,384,9,,CC BY 4.0,idr0033,https://zenodo.org/record/5742744,2020-12-01,3231627,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr/P/8/0/
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080,1080,1,1,1,XYZCT,96,9,,CC0 1.0,idr0094,https://zenodo.org/record/5745520,2020-12-01,10568780,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr/D/5/0/
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271,275,236,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2021-03-09,6001240,
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253,210,257,2,1,XYZCT,,,labels (0),CC BY 4.0,idr0062,,2020-12-01,6001247,
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr,,,,,,,,,bioformats2raw.layout,CC BY 4.0,idr0070,,2022-10-14,9838562,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr/0
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920,1920,,4,,XYC,,,,CC BY 4.0,idr0077,,2021-12-16,9836842,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584,788,142,2,,XYZC ,,,labels (0),CC BY 4.0,idr0079,,2021-12-16,9836998,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (cells, chromosomes)",CC BY 4.0,idr0052,,2021-12-16,5514375,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511419,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511420,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511421,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511422,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511423,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048,2048,,3,,XYC,,,labels (0),CC BY 4.0,idr0095,,2021-12-16,11511424,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr,1080,1080,,,,XY,96,9,,CC0 1.0,idr0094,,2021-12-16,10503791,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr/C/11/0
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560,2160,,,721,XYT,,,,CC BY 4.0,idr0109,,2021-12-16,12922361,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512,512,91,,,XYZ,,,,CC BY 4.0,idr0075,,2021-12-16,9528933,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333,333,201,,79,XYZT,,,,CC BY 4.0,idr0051,,2021-12-16,4007817,
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048,2048,,5,20,XYCT,,,,CC BY 4.0,idr0040,,2021-12-16,3491626,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr,21115,16433,1,3,1,XYZCT,,,,CC BY 4.0,idr0073,,2022-05-05,9798462,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr,1345,1017,1,2,1,XYC,72,20,,CC BY 4.0,idr0072,,2022-05-10,12867352,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr/L/24/0/
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2022-05-11,9822152,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253,210,257,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-05-11,6001247,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169,2048,988,2,532,XYZCT,,,,CC BY 4.0,idr0044,,2022-05-17,4007801,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr,659,493,1,4,1,XYZCT,384,30,bioformats2raw.layout,CC BY 4.0,idr0056,,2022-06-06,9621401,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr/A/1/0/
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0128E/9701.zarr,2048,2048,1,2,1,XYZCT,384,1,bioformats2raw.layout,CC BY 4.0,idr0128,,2022-06-01,13966432,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0128E/9701.zarr/A/12/0/
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0013A/3451.zarr,1344,1024,,,93,XYT,384,1,,CC0 1.0,idr0013,,2022-06-03,1483351,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0013A/3451.zarr/A/2/0
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025551.zarr,2702,2700,1,27,1,XYZCT,,,,CC BY 4.0,idr0054,,2022-06-03,5025551,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025552.zarr,2701,2701,1,27,1,XYZCT,,,,CC BY 4.0,idr0054,,2022-06-03,5025552,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025553.zarr,2500,2500,1,27,1,XYZCT,,,,CC BY 4.0,idr0054,,2022-06-03,5025553,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr,464,494,,50,,XYC,,,labels (0),CC BY 4.0,idr0076,,2022-06-21,10501752,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0047A/4496763.zarr,2048,2048,25,4,,XYZC,,,labels (0),CC BY 4.0,idr0047,,2022-06-21,4496763,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr,271,275,236,2,,XYZC,,,labels (0),CC BY 4.0,idr0062,,2022-06-21,6001240,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0052A/5514375.zarr,256,256,31,3,40,XYZCT,,,"labels (Cell, Chromosomes)",CC BY 4.0,idr0052,,2022-06-21,5514375,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0001A/2551.zarr,1376,1040,16,2,1,XYZC,96,6,labels (0),CC BY 4.0,idr0001,,2022-07-06,1230059,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0001A/2551.zarr/F/6/0
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr,2048,2048,35,4,18,XYZCT,,,,CC BY 4.0,idr0101,,2022-10-13,13457227,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr,198,223,12,6,18,XYZCT,,,coordinateTransformation (translation) on dataset,CC BY 4.0,idr0101,,2022-10-13,13457537,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr,190,189,11,6,18,XYZCT,,,coordinateTransformation (translation) on multiscales,CC BY 4.0,idr0101,,2022-10-13,13457539,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846151.zarr/,2947,5192,1402,3,1,XYZCT,,,bioformats2raw.layout,CC BY 4.0,idr0048,,2023-01-12,9846151,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846151.zarr/0/
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr/,19120,13350,91,3,1,XYZCT,,,,CC BY 4.0,idr0048,,2023-01-12,9846152,
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0138A/TimEmbryos-120919/HybCycle_29/MMStack_Pos9.ome.zarr,2048,2048,6,4,,XYZC,,,,CC BY 4.0,idr0138,,2026-05-12,15158733,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0010/76-45.ome.zarr,,520,1,2,1,XYZCT,384,1,,CC BY 4.0,idr0010,,2024-11-21,1921421,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0010/76-45.ome.zarr/A/2/0/
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0090/190129.zarr,2048,2044,31,5,,XYZC,49,32,,CC BY 4.0,idr0090,,2024-11-21,12539701,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0090/190129.zarr/B/2/0/
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr,6510,8978,,,,XY,,,,CC BY 4.0,idr0066,,2024-11-21,8343616,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpA_VIP_ASLM_on.zarr,2048,2048,1937,,,XYZ,,,,CC BY 4.0,idr0066,,2024-11-21,8343602,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr,271,275,236,2,,XYZC,,,,CC BY 4.0,idr0062,,2024-11-21,6001240,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0157/Asterella gracilis SWE/IMG_1033-1112 Asterella gracilis (Mannia gracilis) stature.ome.zarr,8192,5464,80,3,1,XYZCT,,,,CC BY 4.0,idr0157,,2024-11-21,15154182,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0051/180712_H2B_22ss_Courtney1_20180712-163837_p00_c00_preview.zarr,333,333,201,1,79,XYZCT,,,bioformats2raw.layout,CC BY 4.0,idr0051,,2024-11-21,4007817,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0051/180712_H2B_22ss_Courtney1_20180712-163837_p00_c00_preview.zarr/0/
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0026/3.66.9-6.141020_15-41-29.00.ome.zarr,507,507,21,3,47,XYZCT,,,bioformats2raw.layout,CC BY 4.0,idr0026,,2024-11-21,3261701,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0026/3.66.9-6.141020_15-41-29.00.ome.zarr/0/
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0083/9822152.zarr,144384,93184,1,1,1,XYZCT,,,,CC BY 4.0,idr0083,,2024-11-21,9822152,
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr,2080,1552,,5,,XYC,,,bioformats2raw.layout (9 images),CC BY 4.0,idr0033,,2025-09-22,14002892,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr/0/
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr,1584,788,142,2,,,,,bioformats2raw.layout labels (0),CC BY 4.0,idr0079,,2025-09-22,9836998,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr/0/

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/OMEZarrOpenSciVisDatasets.txt
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/OMEZarrOpenSciVisDatasets.txt
@@ -1,0 +1,510 @@
+Name: aneurism
+Type: uint8
+Size: [256, 256, 256]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/aneurism.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/aneurism.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/aneurism.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/aneurism.ozx
+
+Name: backpack
+Type: uint16
+Size: [512, 512, 373]
+Spacing: [0.9766, 0.9766, 1.25]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/backpack.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/backpack.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/backpack.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/backpack.ozx
+
+Name: beechnut
+Type: uint16
+Size: [1024, 1024, 1546]
+Spacing: [2e-05, 2e-05, 2e-05]
+Scales: 5
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/beechnut.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/beechnut.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/beechnut.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/beechnut.ozx
+
+Name: blunt_fin
+Type: uint8
+Size: [256, 128, 64]
+Spacing: [1, 0.75, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/blunt_fin.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/blunt_fin.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/blunt_fin.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/blunt_fin.ozx
+
+Name: bonsai
+Type: uint8
+Size: [256, 256, 256]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/bonsai.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/bonsai.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/bonsai.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/bonsai.ozx
+
+Name: boston_teapot
+Type: uint8
+Size: [256, 256, 178]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/boston_teapot.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/boston_teapot.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/boston_teapot.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/boston_teapot.ozx
+
+Name: bunny
+Type: uint16
+Size: [512, 512, 361]
+Spacing: [0.337891, 0.337891, 0.5]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/bunny.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/bunny.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/bunny.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/bunny.ozx
+
+Name: carp
+Type: uint16
+Size: [256, 256, 512]
+Spacing: [0.78125, 0.390625, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/carp.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/carp.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/carp.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/carp.ozx
+
+Name: chameleon
+Type: uint16
+Size: [1024, 1024, 1080]
+Spacing: [0.09228515625, 0.09228515625, 0.105]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/chameleon.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/chameleon.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/chameleon.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/chameleon.ozx
+
+Name: christmas_tree
+Type: uint16
+Size: [512, 499, 512]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/christmas_tree.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/christmas_tree.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/christmas_tree.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/christmas_tree.ozx
+
+Name: csafe_heptane
+Type: uint8
+Size: [302, 302, 302]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/csafe_heptane.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/csafe_heptane.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/csafe_heptane.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/csafe_heptane.ozx
+
+Name: duct
+Type: float32
+Size: [193, 194, 1000]
+Spacing: [1, 1, 1]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/duct.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/duct.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/duct.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/duct.ozx
+
+Name: engine
+Type: uint8
+Size: [256, 256, 128]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/engine.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/engine.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/engine.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/engine.ozx
+
+Name: foot
+Type: uint8
+Size: [256, 256, 256]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/foot.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/foot.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/foot.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/foot.ozx
+
+Name: frog
+Type: uint8
+Size: [256, 256, 44]
+Spacing: [0.5, 0.5, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/frog.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/frog.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/frog.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/frog.ozx
+
+Name: fuel
+Type: uint8
+Size: [64, 64, 64]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/fuel.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/fuel.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/fuel.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/fuel.ozx
+
+Name: hcci_oh
+Type: float32
+Size: [560, 560, 560]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/hcci_oh.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/hcci_oh.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/hcci_oh.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/hcci_oh.ozx
+
+Name: hydrogen_atom
+Type: uint8
+Size: [128, 128, 128]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/hydrogen_atom.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/hydrogen_atom.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/hydrogen_atom.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/hydrogen_atom.ozx
+
+Name: jicf_q
+Type: float32
+Size: [1408, 1080, 1100]
+Spacing: [1, 1, 1]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/jicf_q.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/jicf_q.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/jicf_q.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/jicf_q.ozx
+
+Name: kingsnake
+Type: uint8
+Size: [1024, 1024, 795]
+Spacing: [0.03174, 0.03174, 0.0688]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/kingsnake.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/kingsnake.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/kingsnake.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/kingsnake.ozx
+
+Name: lobster
+Type: uint8
+Size: [301, 324, 56]
+Spacing: [1, 1, 1.4]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/lobster.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/lobster.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/lobster.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/lobster.ozx
+
+Name: magnetic_reconnection
+Type: float32
+Size: [512, 512, 512]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/magnetic_reconnection.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/magnetic_reconnection.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/magnetic_reconnection.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/magnetic_reconnection.ozx
+
+Name: marmoset_neurons
+Type: uint8
+Size: [1024, 1024, 314]
+Spacing: [0.497, 0.497, 1.5]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marmoset_neurons.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/marmoset_neurons.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/marmoset_neurons.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/marmoset_neurons.ozx
+
+Name: marschner_lobb
+Type: uint8
+Size: [41, 41, 41]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marschner_lobb.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/marschner_lobb.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/marschner_lobb.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/marschner_lobb.ozx
+
+Name: miranda
+Type: float32
+Size: [1024, 1024, 1024]
+Spacing: [1, 1, 1]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/miranda.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/miranda.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/miranda.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/miranda.ozx
+
+Name: mri_ventricles
+Type: uint8
+Size: [256, 256, 124]
+Spacing: [0.9, 0.9, 0.9]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mri_ventricles.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/mri_ventricles.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/mri_ventricles.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/mri_ventricles.ozx
+
+Name: mri_woman
+Type: uint16
+Size: [256, 256, 109]
+Spacing: [1, 1, 1.5]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mri_woman.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/mri_woman.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/mri_woman.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/mri_woman.ozx
+
+Name: mrt_angio
+Type: uint16
+Size: [416, 512, 112]
+Spacing: [0.412, 0.412, 0.412]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mrt_angio.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/mrt_angio.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/mrt_angio.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/mrt_angio.ozx
+
+Name: neghip
+Type: uint8
+Size: [64, 64, 64]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/neghip.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/neghip.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/neghip.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/neghip.ozx
+
+Name: neocortical_layer_1_axons
+Type: uint8
+Size: [1464, 1033, 76]
+Spacing: [1, 1, 3.4]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/neocortical_layer_1_axons.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/neocortical_layer_1_axons.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/neocortical_layer_1_axons.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/neocortical_layer_1_axons.ozx
+
+Name: nucleon
+Type: uint8
+Size: [41, 41, 41]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/nucleon.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/nucleon.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/nucleon.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/nucleon.ozx
+
+Name: pancreas
+Type: int16
+Size: [240, 512, 512]
+Spacing: [1.16, 1.0, 1.0]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pancreas.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/pancreas.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/pancreas.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/pancreas.ozx
+
+Name: pawpawsaurus
+Type: uint16
+Size: [958, 646, 1088]
+Spacing: [0.2275, 0.2275, 0.2275]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pawpawsaurus.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/pawpawsaurus.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/pawpawsaurus.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/pawpawsaurus.ozx
+
+Name: pig_heart
+Type: int16
+Size: [2048, 2048, 2612]
+Spacing: [0.03557, 0.03557, 0.03557]
+Scales: 5
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pig_heart.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/pig_heart.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/pig_heart.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/pig_heart.ozx
+
+Name: present
+Type: uint16
+Size: [492, 492, 442]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/present.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/present.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/present.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/present.ozx
+
+Name: prone
+Type: uint16
+Size: [512, 512, 463]
+Spacing: [0.625, 0.625, 1.0]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/prone.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/prone.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/prone.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/prone.ozx
+
+Name: richtmyer_meshkov
+Type: uint8
+Size: [2048, 2048, 1920]
+Spacing: [1, 1, 1]
+Scales: 5
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/richtmyer_meshkov.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/richtmyer_meshkov.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/richtmyer_meshkov.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/richtmyer_meshkov.ozx
+
+Name: shockwave
+Type: uint8
+Size: [64, 64, 512]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/shockwave.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/shockwave.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/shockwave.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/shockwave.ozx
+
+Name: silicium
+Type: uint8
+Size: [98, 34, 34]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/silicium.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/silicium.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/silicium.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/silicium.ozx
+
+Name: skull
+Type: uint8
+Size: [256, 256, 256]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/skull.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/skull.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/skull.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/skull.ozx
+
+Name: spathorhynchus
+Type: uint16
+Size: [1024, 1024, 750]
+Spacing: [0.0215, 0.0215, 0.047]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/spathorhynchus.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/spathorhynchus.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/spathorhynchus.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/spathorhynchus.ozx
+
+Name: stag_beetle
+Type: uint16
+Size: [832, 832, 494]
+Spacing: [1, 1, 1]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/stag_beetle.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/stag_beetle.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/stag_beetle.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/stag_beetle.ozx
+
+Name: statue_leg
+Type: uint8
+Size: [341, 341, 93]
+Spacing: [1, 1, 4]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/statue_leg.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/statue_leg.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/statue_leg.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/statue_leg.ozx
+
+Name: stent
+Type: uint16
+Size: [512, 512, 174]
+Spacing: [0.8398, 0.8398, 3.2]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/stent.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/stent.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/stent.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/stent.ozx
+
+Name: synthetic_truss_with_five_defects
+Type: float32
+Size: [1200, 1200, 1200]
+Spacing: [1, 1, 1]
+Scales: 4
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/synthetic_truss_with_five_defects.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/synthetic_truss_with_five_defects.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/synthetic_truss_with_five_defects.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/synthetic_truss_with_five_defects.ozx
+
+Name: tacc_turbulence
+Type: float32
+Size: [256, 256, 256]
+Spacing: [1, 1, 1]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/tacc_turbulence.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/tacc_turbulence.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/tacc_turbulence.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/tacc_turbulence.ozx
+
+Name: tooth
+Type: uint8
+Size: [103, 94, 161]
+Spacing: [1, 1, 1]
+Scales: 1
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/tooth.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/tooth.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/tooth.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/tooth.ozx
+
+Name: vertebra
+Type: uint16
+Size: [512, 512, 512]
+Spacing: [0.1953, 0.1953, 0.1953]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/vertebra.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/vertebra.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/vertebra.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/vertebra.ozx
+
+Name: vis_male
+Type: uint8
+Size: [128, 256, 256]
+Spacing: [1.57774, 0.995861, 1.00797]
+Scales: 2
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/vis_male.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/vis_male.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/vis_male.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/vis_male.ozx
+
+Name: woodbranch
+Type: uint16
+Size: [2048, 2048, 2048]
+Spacing: [1.8e-05, 1.8e-05, 1.8e-05]
+Scales: 5
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/woodbranch.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/woodbranch.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/woodbranch.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/woodbranch.ozx
+
+Name: zeiss
+Type: uint8
+Size: [680, 680, 680]
+Spacing: [1, 1, 1]
+Scales: 3
+HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/zeiss.ome.zarr
+S3 URL: s3://ome-zarr-scivis/v0.5/96x2/zeiss.ome.zarr
+OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/zeiss.ozx
+OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/zeiss.ozx
+

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/convert_to_one_csv.py
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/convert_to_one_csv.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+import pandas as pd
+
+
+def parse_OpenSciVis_processed_README(path: str) -> list[dict]:
+    """
+    The processed README shall feature repeating 10-lines-long blocks, e.g.:
+
+    <block start, not part of the file>
+    Name: backpack
+    Type: uint16
+    Size: [512, 512, 373]
+    Spacing: [0.9766, 0.9766, 1.25]
+    Scales: 3
+    HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/backpack.ome.zarr
+    S3 URL: s3://ome-zarr-scivis/v0.5/96x2/backpack.ome.zarr
+    OZX HTTPS URL: https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2-ozx/backpack.ozx
+    OZX S3 URL: s3://ome-zarr-scivis/v0.5/96x2-ozx/backpack.ozx
+
+    </block end, not part of the file; NOTE THE MANDATORY EMPTY LINE>
+
+    The README (as of 2026/06) found on InsightSoftwareConsortium consisted of 51 records/blocks.
+    """
+    lines = Path(path).read_text().splitlines()
+
+    assert len(lines) == 51 * 10, f"Expected 510 lines, got {len(lines)}"
+
+    records = []
+    for i in range(0, len(lines), 10):
+        chunk = lines[i:i + 10]
+        record = {}
+        for line in chunk:
+            key, _, value = line.partition(":")
+            record[key.strip()] = value.strip()
+        records.append(record)
+
+    return records
+
+
+def to_dataframe(records: list[dict]) -> "pd.DataFrame":
+    rows = []
+    for r in records:
+        size_x, size_y, size_z = (int(v) for v in r["Size"].strip("[]").split(","))
+        scale_x, scale_y, scale_z = (float(v) for v in r["Spacing"].strip("[]").split(","))
+
+        rows.append({
+            "OME-NGFF version": 0.5,
+            "File Path":          r["HTTPS URL"],
+            "DataType":           r["Type"],
+            "SizeX":              size_x,
+            "SizeY":              size_y,
+            "SizeZ":              size_z,
+            "ScaleX":             scale_x,
+            "ScaleY":             scale_y,
+            "ScaleZ":             scale_z,
+            "NumberOfResLevels":  int(r["Scales"]),
+            "Axes":               "XYZ",
+            "License":            "Apache-2.0",
+            "Study":              r["Name"],
+        })
+
+    return pd.DataFrame(rows)
+
+
+def adapt_columns_in_IDR_table(table):
+    """
+    Original IDR columns (as of 2026/06) are:
+
+    OME-NGFF version, File Path, SizeX, SizeY, SizeZ, SizeC, SizeT,
+    Axes, Wells, Fields, Keywords, License, Study, DOI, Date added,
+    Representative Image ID, Thumbnail
+
+    That gets here reduced to (output of this function):
+
+    OME-NGFF version, File Path, SizeX, SizeY, SizeZ, SizeC, SizeT,
+    Axes, Wells, Fields, License, Study
+
+    Removing these:
+    Keywords, DOI, Date added, Representative Image ID, Thumbnail
+
+    Furthermore, the following columns will be added:
+    DataType, ScaleX, ScaleY, ScaleZ, NumberOfResLevels
+    """
+    new_t = table[[ "OME-NGFF version", "File Path",
+                    "SizeX", "SizeY", "SizeZ", "SizeC", "SizeT",
+                    "Axes", "Wells", "Fields", "License", "Study" ]]
+    new_t["DataType"] = ""
+    new_t["ScaleX"] = -1
+    new_t["ScaleY"] = -1
+    new_t["ScaleZ"] = -1
+    new_t["NumberOfResLevels"] = -1
+    return new_t
+
+
+
+def this_is_how_to_use():
+    t1 = adapt_columns_in_IDR_table( pd.read_csv('IDR_table.csv') )
+
+    list_of_dict = parse_OpenSciVis_processed_README('OMEZarrOpenSciVisDatasets.txt')
+    t2 = to_dataframe(list_of_dict)
+
+    df = pd.concat([t1, t2], ignore_index=True)
+    df.to_csv('testbed_datasets.csv', index=False)
+

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/source_links.txt
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/source_links.txt
@@ -1,0 +1,5 @@
+Open SciVis Datasets:   https://raw.githubusercontent.com/InsightSoftwareConsortium/OMEZarrOpenSciVisDatasets/refs/heads/main/README.md
+                        http://klacansky.com/open-scivis-datasets/datasets.json
+
+IDR table:              https://raw.githubusercontent.com/IDR/ome-ngff-samples/refs/heads/main/_data/table.csv
+

--- a/test-shared/resources/ome/zarr/testdata/conformance_testing/testbed_datasets.csv
+++ b/test-shared/resources/ome/zarr/testdata/conformance_testing/testbed_datasets.csv
@@ -1,0 +1,153 @@
+OME-NGFF version,File Path,SizeX,SizeY,SizeZ,SizeC,SizeT,Axes,Wells,Fields,License,Study,DataType,ScaleX,ScaleY,ScaleZ,NumberOfResLevels
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/12689244.zarr,4992.0,4255.0,401.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0106,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/179706.zarr,1344.0,1024.0,1.0,2.0,329.0,XYZCT,,,CC BY 4.0,idr0002,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/1884807.zarr,256.0,256.0,1.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0021,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/1885619.zarr,30.0,30.0,571.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0023,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/4495402.zarr,921600.0,380928.0,1.0,1.0,1.0,XYZCT,,,CC BY-NC-SA 3.0,idr0053,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr,1024.0,1024.0,39.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001238.zarr,1024.0,1024.0,27.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001239.zarr,1024.0,1024.0,36.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr,271.0,275.0,236.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001241.zarr,278.0,263.0,236.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001242.zarr,481.0,275.0,237.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001243.zarr,212.0,218.0,237.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001244.zarr,325.0,281.0,239.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001245.zarr,220.0,226.0,257.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001246.zarr,281.0,284.0,257.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001247.zarr,253.0,210.0,257.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001248.zarr,234.0,269.0,195.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001249.zarr,246.0,241.0,195.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001250.zarr,246.0,241.0,195.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001251.zarr,170.0,163.0,140.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001252.zarr,170.0,163.0,297.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr,803.0,1024.0,297.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001254.zarr,393.0,354.0,51.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001255.zarr,551.0,416.0,32.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001256.zarr,350.0,372.0,61.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001257.zarr,3763.0,2860.0,145.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/6001258.zarr,1282.0,838.0,36.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9822151.zarr,79360.0,167424.0,1.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0083,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9822152.zarr,144384.0,93184.0,1.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0083,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836832.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836833.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836834.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836835.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836836.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836837.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836838.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836839.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836840.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836841.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836842.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836843.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836844.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836845.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836846.zarr,1920.0,1920.0,259.0,4.0,1.0,XYZCT,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/9836950.zarr,1636.0,816.0,156.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0079,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/1751.zarr,672.0,510.0,10.0,2.0,1.0,XYZCT,69.0,1.0,CC BY-NC-SA 3.0,idr0004,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/2551.zarr,1376.0,1040.0,16.0,2.0,1.0,XYZCT,96.0,6.0,CC BY 4.0,idr0001,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/422.zarr,1344.0,1024.0,1.0,2.0,329.0,XYZCT,96.0,1.0,CC BY 4.0,idr0002,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr,1080.0,1080.0,1.0,5.0,1.0,XYZCT,384.0,9.0,CC BY 4.0,idr0033,,-1.0,-1.0,-1.0,-1
+0.1,https://livingobjects.ebi.ac.uk/idr/zarr/v0.1/plates/7825.zarr,1080.0,1080.0,1.0,1.0,1.0,XYZCT,96.0,9.0,CC0 1.0,idr0094,,-1.0,-1.0,-1.0,-1
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/6001240.zarr,271.0,275.0,236.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/6001247.zarr,253.0,210.0,257.0,2.0,1.0,XYZCT,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.2,https://livingobjects.ebi.ac.uk/idr/zarr/v0.2/idr0070A/9838562.zarr,,,,,,,,,CC BY 4.0,idr0070,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr,1920.0,1920.0,,4.0,,XYC,,,CC BY 4.0,idr0077,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0079A/9836998.zarr,1584.0,788.0,142.0,2.0,,XYZC ,,,CC BY 4.0,idr0079,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0052A/5514375.zarr,256.0,256.0,31.0,3.0,40.0,XYZCT,,,CC BY 4.0,idr0052,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511419.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511420.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511421.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511422.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511423.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0095B/11511424.zarr,2048.0,2048.0,,3.0,,XYC,,,CC BY 4.0,idr0095,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0094A/7751.zarr,1080.0,1080.0,,,,XY,96.0,9.0,CC0 1.0,idr0094,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0109A/12922361.zarr,2560.0,2160.0,,,721.0,XYT,,,CC BY 4.0,idr0109,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0075A/9528933.zarr,512.0,512.0,91.0,,,XYZ,,,CC BY 4.0,idr0075,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0051A/4007817.zarr,333.0,333.0,201.0,,79.0,XYZT,,,CC BY 4.0,idr0051,,-1.0,-1.0,-1.0,-1
+0.3,https://livingobjects.ebi.ac.uk/idr/zarr/v0.3/idr0040A/3491626.zarr,2048.0,2048.0,,5.0,20.0,XYCT,,,CC BY 4.0,idr0040,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr,21115.0,16433.0,1.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0073,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr,1345.0,1017.0,1.0,2.0,1.0,XYC,72.0,20.0,CC BY 4.0,idr0072,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr,144384.0,93184.0,1.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0083,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001247.zarr,253.0,210.0,257.0,2.0,,XYZC,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0044A/4007801.zarr,2169.0,2048.0,988.0,2.0,532.0,XYZCT,,,CC BY 4.0,idr0044,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr,659.0,493.0,1.0,4.0,1.0,XYZCT,384.0,30.0,CC BY 4.0,idr0056,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0128E/9701.zarr,2048.0,2048.0,1.0,2.0,1.0,XYZCT,384.0,1.0,CC BY 4.0,idr0128,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0013A/3451.zarr,1344.0,1024.0,,,93.0,XYT,384.0,1.0,CC0 1.0,idr0013,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025551.zarr,2702.0,2700.0,1.0,27.0,1.0,XYZCT,,,CC BY 4.0,idr0054,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025552.zarr,2701.0,2701.0,1.0,27.0,1.0,XYZCT,,,CC BY 4.0,idr0054,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0054A/5025553.zarr,2500.0,2500.0,1.0,27.0,1.0,XYZCT,,,CC BY 4.0,idr0054,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0076A/10501752.zarr,464.0,494.0,,50.0,,XYC,,,CC BY 4.0,idr0076,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0047A/4496763.zarr,2048.0,2048.0,25.0,4.0,,XYZC,,,CC BY 4.0,idr0047,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr,271.0,275.0,236.0,2.0,,XYZC,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0052A/5514375.zarr,256.0,256.0,31.0,3.0,40.0,XYZCT,,,CC BY 4.0,idr0052,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0001A/2551.zarr,1376.0,1040.0,16.0,2.0,1.0,XYZC,96.0,6.0,CC BY 4.0,idr0001,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457227.zarr,2048.0,2048.0,35.0,4.0,18.0,XYZCT,,,CC BY 4.0,idr0101,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr,198.0,223.0,12.0,6.0,18.0,XYZCT,,,CC BY 4.0,idr0101,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr,190.0,189.0,11.0,6.0,18.0,XYZCT,,,CC BY 4.0,idr0101,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846151.zarr/,2947.0,5192.0,1402.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0048,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846152.zarr/,19120.0,13350.0,91.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0048,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0138A/TimEmbryos-120919/HybCycle_29/MMStack_Pos9.ome.zarr,2048.0,2048.0,6.0,4.0,,XYZC,,,CC BY 4.0,idr0138,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0010/76-45.ome.zarr,,520.0,1.0,2.0,1.0,XYZCT,384.0,1.0,CC BY 4.0,idr0010,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0090/190129.zarr,2048.0,2044.0,31.0,5.0,,XYZC,49.0,32.0,CC BY 4.0,idr0090,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpD_chicken_embryo_MIP.ome.zarr,6510.0,8978.0,,,,XY,,,CC BY 4.0,idr0066,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0066/ExpA_VIP_ASLM_on.zarr,2048.0,2048.0,1937.0,,,XYZ,,,CC BY 4.0,idr0066,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr,271.0,275.0,236.0,2.0,,XYZC,,,CC BY 4.0,idr0062,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0157/Asterella gracilis SWE/IMG_1033-1112 Asterella gracilis (Mannia gracilis) stature.ome.zarr,8192.0,5464.0,80.0,3.0,1.0,XYZCT,,,CC BY 4.0,idr0157,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0051/180712_H2B_22ss_Courtney1_20180712-163837_p00_c00_preview.zarr,333.0,333.0,201.0,1.0,79.0,XYZCT,,,CC BY 4.0,idr0051,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0026/3.66.9-6.141020_15-41-29.00.ome.zarr,507.0,507.0,21.0,3.0,47.0,XYZCT,,,CC BY 4.0,idr0026,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0083/9822152.zarr,144384.0,93184.0,1.0,1.0,1.0,XYZCT,,,CC BY 4.0,idr0083,,-1.0,-1.0,-1.0,-1
+0.5,https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0033A/BR00109990_C2.zarr,2080.0,1552.0,,5.0,,XYC,,,CC BY 4.0,idr0033,,-1.0,-1.0,-1.0,-1
+0.4,https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0079A/idr0079_images.zarr,1584.0,788.0,142.0,2.0,,,,,CC BY 4.0,idr0079,,-1.0,-1.0,-1.0,-1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/aneurism.ome.zarr,256.0,256.0,256.0,,,XYZ,,,Apache-2.0,aneurism,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/backpack.ome.zarr,512.0,512.0,373.0,,,XYZ,,,Apache-2.0,backpack,uint16,0.9766,0.9766,1.25,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/beechnut.ome.zarr,1024.0,1024.0,1546.0,,,XYZ,,,Apache-2.0,beechnut,uint16,2e-05,2e-05,2e-05,5
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/blunt_fin.ome.zarr,256.0,128.0,64.0,,,XYZ,,,Apache-2.0,blunt_fin,uint8,1.0,0.75,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/bonsai.ome.zarr,256.0,256.0,256.0,,,XYZ,,,Apache-2.0,bonsai,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/boston_teapot.ome.zarr,256.0,256.0,178.0,,,XYZ,,,Apache-2.0,boston_teapot,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/bunny.ome.zarr,512.0,512.0,361.0,,,XYZ,,,Apache-2.0,bunny,uint16,0.337891,0.337891,0.5,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/carp.ome.zarr,256.0,256.0,512.0,,,XYZ,,,Apache-2.0,carp,uint16,0.78125,0.390625,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/chameleon.ome.zarr,1024.0,1024.0,1080.0,,,XYZ,,,Apache-2.0,chameleon,uint16,0.09228515625,0.09228515625,0.105,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/christmas_tree.ome.zarr,512.0,499.0,512.0,,,XYZ,,,Apache-2.0,christmas_tree,uint16,1.0,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/csafe_heptane.ome.zarr,302.0,302.0,302.0,,,XYZ,,,Apache-2.0,csafe_heptane,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/duct.ome.zarr,193.0,194.0,1000.0,,,XYZ,,,Apache-2.0,duct,float32,1.0,1.0,1.0,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/engine.ome.zarr,256.0,256.0,128.0,,,XYZ,,,Apache-2.0,engine,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/foot.ome.zarr,256.0,256.0,256.0,,,XYZ,,,Apache-2.0,foot,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/frog.ome.zarr,256.0,256.0,44.0,,,XYZ,,,Apache-2.0,frog,uint8,0.5,0.5,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/fuel.ome.zarr,64.0,64.0,64.0,,,XYZ,,,Apache-2.0,fuel,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/hcci_oh.ome.zarr,560.0,560.0,560.0,,,XYZ,,,Apache-2.0,hcci_oh,float32,1.0,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/hydrogen_atom.ome.zarr,128.0,128.0,128.0,,,XYZ,,,Apache-2.0,hydrogen_atom,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/jicf_q.ome.zarr,1408.0,1080.0,1100.0,,,XYZ,,,Apache-2.0,jicf_q,float32,1.0,1.0,1.0,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/kingsnake.ome.zarr,1024.0,1024.0,795.0,,,XYZ,,,Apache-2.0,kingsnake,uint8,0.03174,0.03174,0.0688,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/lobster.ome.zarr,301.0,324.0,56.0,,,XYZ,,,Apache-2.0,lobster,uint8,1.0,1.0,1.4,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/magnetic_reconnection.ome.zarr,512.0,512.0,512.0,,,XYZ,,,Apache-2.0,magnetic_reconnection,float32,1.0,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marmoset_neurons.ome.zarr,1024.0,1024.0,314.0,,,XYZ,,,Apache-2.0,marmoset_neurons,uint8,0.497,0.497,1.5,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/marschner_lobb.ome.zarr,41.0,41.0,41.0,,,XYZ,,,Apache-2.0,marschner_lobb,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/miranda.ome.zarr,1024.0,1024.0,1024.0,,,XYZ,,,Apache-2.0,miranda,float32,1.0,1.0,1.0,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mri_ventricles.ome.zarr,256.0,256.0,124.0,,,XYZ,,,Apache-2.0,mri_ventricles,uint8,0.9,0.9,0.9,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mri_woman.ome.zarr,256.0,256.0,109.0,,,XYZ,,,Apache-2.0,mri_woman,uint16,1.0,1.0,1.5,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/mrt_angio.ome.zarr,416.0,512.0,112.0,,,XYZ,,,Apache-2.0,mrt_angio,uint16,0.412,0.412,0.412,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/neghip.ome.zarr,64.0,64.0,64.0,,,XYZ,,,Apache-2.0,neghip,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/neocortical_layer_1_axons.ome.zarr,1464.0,1033.0,76.0,,,XYZ,,,Apache-2.0,neocortical_layer_1_axons,uint8,1.0,1.0,3.4,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/nucleon.ome.zarr,41.0,41.0,41.0,,,XYZ,,,Apache-2.0,nucleon,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pancreas.ome.zarr,240.0,512.0,512.0,,,XYZ,,,Apache-2.0,pancreas,int16,1.16,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pawpawsaurus.ome.zarr,958.0,646.0,1088.0,,,XYZ,,,Apache-2.0,pawpawsaurus,uint16,0.2275,0.2275,0.2275,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/pig_heart.ome.zarr,2048.0,2048.0,2612.0,,,XYZ,,,Apache-2.0,pig_heart,int16,0.03557,0.03557,0.03557,5
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/present.ome.zarr,492.0,492.0,442.0,,,XYZ,,,Apache-2.0,present,uint16,1.0,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/prone.ome.zarr,512.0,512.0,463.0,,,XYZ,,,Apache-2.0,prone,uint16,0.625,0.625,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/richtmyer_meshkov.ome.zarr,2048.0,2048.0,1920.0,,,XYZ,,,Apache-2.0,richtmyer_meshkov,uint8,1.0,1.0,1.0,5
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/shockwave.ome.zarr,64.0,64.0,512.0,,,XYZ,,,Apache-2.0,shockwave,uint8,1.0,1.0,1.0,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/silicium.ome.zarr,98.0,34.0,34.0,,,XYZ,,,Apache-2.0,silicium,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/skull.ome.zarr,256.0,256.0,256.0,,,XYZ,,,Apache-2.0,skull,uint8,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/spathorhynchus.ome.zarr,1024.0,1024.0,750.0,,,XYZ,,,Apache-2.0,spathorhynchus,uint16,0.0215,0.0215,0.047,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/stag_beetle.ome.zarr,832.0,832.0,494.0,,,XYZ,,,Apache-2.0,stag_beetle,uint16,1.0,1.0,1.0,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/statue_leg.ome.zarr,341.0,341.0,93.0,,,XYZ,,,Apache-2.0,statue_leg,uint8,1.0,1.0,4.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/stent.ome.zarr,512.0,512.0,174.0,,,XYZ,,,Apache-2.0,stent,uint16,0.8398,0.8398,3.2,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/synthetic_truss_with_five_defects.ome.zarr,1200.0,1200.0,1200.0,,,XYZ,,,Apache-2.0,synthetic_truss_with_five_defects,float32,1.0,1.0,1.0,4
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/tacc_turbulence.ome.zarr,256.0,256.0,256.0,,,XYZ,,,Apache-2.0,tacc_turbulence,float32,1.0,1.0,1.0,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/tooth.ome.zarr,103.0,94.0,161.0,,,XYZ,,,Apache-2.0,tooth,uint8,1.0,1.0,1.0,1
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/vertebra.ome.zarr,512.0,512.0,512.0,,,XYZ,,,Apache-2.0,vertebra,uint16,0.1953,0.1953,0.1953,3
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/vis_male.ome.zarr,128.0,256.0,256.0,,,XYZ,,,Apache-2.0,vis_male,uint8,1.57774,0.995861,1.00797,2
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/woodbranch.ome.zarr,2048.0,2048.0,2048.0,,,XYZ,,,Apache-2.0,woodbranch,uint16,1.8e-05,1.8e-05,1.8e-05,5
+0.5,https://ome-zarr-scivis.s3.us-east-1.amazonaws.com/v0.5/96x2/zeiss.ome.zarr,680.0,680.0,680.0,,,XYZ,,,Apache-2.0,zeiss,uint8,1.0,1.0,1.0,3


### PR DESCRIPTION
### Notes

Reconstructs #91 ("Testbed tool, conformance report table and reference datasets") on top of the five-module split (#95, #94, #93). The original commits predate that refactoring and no longer apply cleanly, so this is a fresh, equivalent port rather than a `git rebase`.

See https://github.com/BioImageTools/ome-zarr-fiji-java/pull/96/changes/cbd1cc11677ca651f711b7023ddf24f202dadafa for a description of the required changes to adapt to the new module structure

# Description

This PR is currently a work-in-progress.

Its purpose is to have two entry test methods

- A pure unit-test method that opens a given dataset using a given backend, shows an IJ window (to simulate a real user wanting to display an OME-Zarr dataset), and checks various parameters with asserts. This method is called iteratively over a collection of test data produced by `testCasesFeeder()`.
- Another method that iteratively calls the previous one, monitors its asserts, and builds up a *conformance tests overview table*, see below.

The first method is clearly the workhorse here. Additionally, the class `TestDataset` is crucial to the method's testing capability, as it contains a pointer to the source dataset and numerous dataset parameters, such as axis sizes, the number of resolution levels, pixel resolutions, axis order, etc. The workhorse method only verifies matches between the actual values (from the `PyramidDataset` object created at runtime) and the reference values (from the `TestDataset` object) over the said parameters.

The folder `/testing` currently holds aux tools to create a `.csv` table, see also #88, that feeds and arrives into `TestDataset` objects.

The second method `reportSuccessRateAndPrintTable()` can give an output like this:

```text
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
| Dataset                                                                        | Backend   | Result | Reason                                                                         |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                            file://...../2d_dataset_v5.ome.zarr (idr0106) v0.5: |        N5 |   PASS |                                                                                |
|                         size=(64 x 64 x 1 x 1 x 1) [XYZCT], axes='XY', pxType= |           |        |                                                                                |
|     multiscales=-1, wells=-1, fields=-1, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                            file://...../2d_dataset_v5.ome.zarr (idr0106) v0.5: | ZARR_JAVA |   PASS |                                                                                |
|                         size=(64 x 64 x 1 x 1 x 1) [XYZCT], axes='XY', pxType= |           |        |                                                                                |
|     multiscales=-1, wells=-1, fields=-1, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                 https://ome-z.....s.com/...../miranda.ome.zarr (miranda) v0.5: |        N5 |   PASS |                                                                                |
|        size=(1024 x 1024 x 1024 x -1 x -1) [XYZCT], axes='XYZ', pxType=float32 |           |        |                                                                                |
|         multiscales=4, wells=-1, fields=-1, resolution=(1.0 x 1.0 x 1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                 https://ome-z.....s.com/...../miranda.ome.zarr (miranda) v0.5: | ZARR_JAVA |   FAIL | AssertionFailedError: Failed opening dataset 'miranda' with IJ. ==> Unexpected |
|        size=(1024 x 1024 x 1024 x -1 x -1) [XYZCT], axes='XYZ', pxType=float32 |           |        |                                  exception thrown: java.lang.RuntimeException: |
|         multiscales=4, wells=-1, fields=-1, resolution=(1.0 x 1.0 x 1.0) [XYZ] |           |        |                                       java.util.concurrent.ExecutionException: |
|                                                                                |           |        |                                       java.lang.ArrayIndexOutOfBoundsException |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|     https://ome-z.....s.com/...../marmoset_neurons.ome.zarr (marmoset_neurons) |        N5 |   PASS |                                                                                |
|                                                                          v0.5: |           |        |                                                                                |
|           size=(1024 x 1024 x 314 x -1 x -1) [XYZCT], axes='XYZ', pxType=uint8 |           |        |                                                                                |
|     multiscales=4, wells=-1, fields=-1, resolution=(0.497 x 0.497 x 1.5) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|     https://ome-z.....s.com/...../marmoset_neurons.ome.zarr (marmoset_neurons) | ZARR_JAVA |   PASS |                                                                                |
|                                                                          v0.5: |           |        |                                                                                |
|           size=(1024 x 1024 x 314 x -1 x -1) [XYZCT], axes='XYZ', pxType=uint8 |           |        |                                                                                |
|     multiscales=4, wells=-1, fields=-1, resolution=(0.497 x 0.497 x 1.5) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                     https://livin.....ac.uk/...../9798462.zarr (idr0073) v0.4: |        N5 |   PASS |                                                                                |
|                size=(21115 x 16433 x 1 x 3 x 1) [XYZCT], axes='XYZCT', pxType= |           |        |                                                                                |
|     multiscales=-1, wells=-1, fields=-1, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                     https://livin.....ac.uk/...../9798462.zarr (idr0073) v0.4: | ZARR_JAVA |   FAIL | AssertionFailedError: Failed opening dataset 'idr0073' with IJ. ==> Unexpected |
|                size=(21115 x 16433 x 1 x 3 x 1) [XYZCT], axes='XYZCT', pxType= |           |        |                                                              exception thrown: |
|     multiscales=-1, wells=-1, fields=-1, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |   sc.fiji.ome.zarr.pyramid.exceptions.PyramidLevelAccessException: Cannot open |
|                                                                                |           |        |                                                         resolution level 0 of: |
|                                                                                |           |        |            https://livingobjects.ebi.ac.uk/idr/zarr/v0.4/idr0073A/9798462.zarr |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                        https://livin.....ac.uk/...../9512.zarr (idr0072) v0.4: |        N5 |   FAIL |      AssertionFailedError: After opening, no Dataset is available in Fiji. ==> |
|                    size=(1345 x 1017 x 1 x 2 x 1) [XYZCT], axes='XYC', pxType= |           |        |                                                     expected: <1> but was: <0> |
|     multiscales=-1, wells=72, fields=20, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+
|                        https://livin.....ac.uk/...../9512.zarr (idr0072) v0.4: | ZARR_JAVA |   FAIL |      AssertionFailedError: After opening, no Dataset is available in Fiji. ==> |
|                    size=(1345 x 1017 x 1 x 2 x 1) [XYZCT], axes='XYC', pxType= |           |        |                                                     expected: <1> but was: <0> |
|     multiscales=-1, wells=72, fields=20, resolution=(-1.0 x -1.0 x -1.0) [XYZ] |           |        |                                                                                |
+--------------------------------------------------------------------------------+-----------+--------+--------------------------------------------------------------------------------+

Passed: 6 / 10
```

# TODO
- Fully populate the source .csv table, as it is currently missing values for some datasets. These are the '-1' or '' values.
- Consider creating and including dummy OME-Zarr datasets that would be created "around" .json files from the official ngff spec repo.
- Consider using our internal dataset (in the resources folder).
- Move the .csv to the resources section of the package.